### PR TITLE
Specify PHP versions explicitly

### DIFF
--- a/php-80/cpu-arm.Dockerfile
+++ b/php-80/cpu-arm.Dockerfile
@@ -1,5 +1,11 @@
 FROM public.ecr.aws/lambda/provided:al2-arm64 as binary
 
+# Specifying the exact PHP version lets us avoid the Docker cache when a new version comes out
+ENV VERSION_PHP=8.0.20-1
+# Check out the latest version available by running:
+# docker run --rm -it --entrypoint=bash public.ecr.aws/lambda/provided:al2-arm64 -c "yum install -y amazon-linux-extras && amazon-linux-extras enable php8.0 && yum list php-cli"
+
+
 # Work in a temporary /bref dir to avoid any conflict/mixup with other /opt files
 # /bref will eventually be moved to /opt
 RUN mkdir /bref \
@@ -11,7 +17,9 @@ RUN yum install -y amazon-linux-extras
 
 RUN amazon-linux-extras enable php8.0
 
-RUN yum install -y curl php-cli php-sodium unzip
+# --setopt=skip_missing_names_on_install=False makes sure we get an error if a package is missing
+RUN yum install --setopt=skip_missing_names_on_install=False -y \
+        php-cli-${VERSION_PHP}.amzn2 php-sodium unzip curl
 
 # These files are included on Amazon Linux 2
 

--- a/php-80/cpu-x86.Dockerfile
+++ b/php-80/cpu-x86.Dockerfile
@@ -1,5 +1,11 @@
 FROM public.ecr.aws/lambda/provided:al2-x86_64 as binary
 
+# Specifying the exact PHP version lets us avoid the Docker cache when a new version comes out
+ENV VERSION_PHP=8.0.24-1
+# Check out the latest version available on this page:
+# https://rpms.remirepo.net/enterprise/7/php80/x86_64/repoview/php.html
+
+
 # Work in a temporary /bref dir to avoid any conflict/mixup with other /opt files
 # /bref will eventually be moved to /opt
 RUN mkdir /bref \
@@ -18,7 +24,9 @@ RUN yum-config-manager --enable remi-php80
 
 RUN yum update -y && yum upgrade -y
 
-RUN yum install -y php80-php
+# --setopt=skip_missing_names_on_install=False makes sure we get an error if a package is missing
+RUN yum install --setopt=skip_missing_names_on_install=False -y \
+        php80-php-${VERSION_PHP}.el7.remi.x86_64
 
 # These files are included on Amazon Linux 2
 

--- a/php-81/cpu-x86.Dockerfile
+++ b/php-81/cpu-x86.Dockerfile
@@ -1,5 +1,11 @@
 FROM public.ecr.aws/lambda/provided:al2-x86_64 as binary
 
+# Specifying the exact PHP version lets us avoid the Docker cache when a new version comes out
+ENV VERSION_PHP=8.1.11-1
+# Check out the latest version available on this page:
+# https://rpms.remirepo.net/enterprise/7/php81/x86_64/repoview/php.html
+
+
 # Work in a temporary /bref dir to avoid any conflict/mixup with other /opt files
 # /bref will eventually be moved to /opt
 RUN mkdir /bref \
@@ -18,7 +24,9 @@ RUN yum-config-manager --enable remi-php81
 
 RUN yum update -y && yum upgrade -y
 
-RUN yum install -y php81-php
+# --setopt=skip_missing_names_on_install=False makes sure we get an error if a package is missing
+RUN yum install --setopt=skip_missing_names_on_install=False -y \
+        php81-php-${VERSION_PHP}.el7.remi.x86_64
 
 # These files are included on Amazon Linux 2
 


### PR DESCRIPTION
That way we *know* which version is actually installed, instead of the versions depending on _when_ the layers were built.

That will also help with the general flow: contributors can send PRs to increase PHP versions when they come out. Instead of randomly having to rebuild layers in the hopes that it will bundle a new PHP version.