### PR TITLE
Support Europe/Spain region

### DIFF
--- a/utils/lambda-publish/Makefile
+++ b/utils/lambda-publish/Makefile
@@ -32,6 +32,7 @@ europe-1:
 europe-2:
 	REGION=eu-north-1 ./publish.sh #Europe (Stockholm)
 	REGION=eu-south-1 ./publish.sh #Europe (Milan)
+	REGION=eu-south-2 ./publish.sh #Europe (Spain)
 	REGION=eu-central-1 ./publish.sh #Europe (Frankfurt)
 
 asia-1:


### PR DESCRIPTION
<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.
-->

Closes #28 

Recently a new AWS region was launched in Europe/Spain
This PR adds support for "eu-south-2" and pushes layers to that region also
