### PR TITLE
Provide `build-` images like Bref 1 to allow building extra extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,27 +158,24 @@ isolated into the `/bref` folder. The use of multiple Docker Layers helps with i
 because the developer can have a faster feedback loop by checking each step of the process incrementally instead
 of trying to figure out why an entire build is failing.
 
-The 2nd layer is the `extensions` where all extensions are installed and isolated into the `/bref` folder.
-Reminder that `ldd` is a linux utility that helps discover which files need isolating.
-
-The 3rd layer is the `isolation` layer where we'll start from the standard AWS-provided image all over again
+The 2nd layer is the `isolation` layer where we'll start from the standard AWS-provided image all over again
 (getting rid of any residual unnecessary file) and then copying `/bref` into `/opt`. PHP Configurations are
 copied here as well.
 
-The 4th layer is the `function` layer where everything is packet together and the `bootstrap` file is loaded.
+The 3rd layer is the `function` layer where everything is packet together and the `bootstrap` file is loaded.
 The `bref-internal-src` images (see layers/fpm) are used to load Bref
 classes into the layer.
 
-The 5th layer is `zip-function`, where we get a small and fast Linux (Alpine) just to install and zip the entire
+The 4th layer is `zip-function`, where we get a small and fast Linux (Alpine) just to install and zip the entire
 `/opt` content. We use docker-compose volumes to map `/tmp/bref-zip` from host to the container so that we can
 zip everything and get the zipped file out of the container.
 
-The 6th layer goes back to `extensions` and start `fpm-extension`. Here we're back at step 2 so that we can install
+The 5th layer goes back to `extensions` and start `fpm-extension`. Here we're back at step 2 so that we can install
 `fpm`.
 
-The 7th layer goes back to `isolation` and start `fpm`. It mimics steps 3th and 4th but for the FPM Layer.
+The 6th layer goes back to `isolation` and start `fpm`. It mimics steps 3th and 4th but for the FPM Layer.
 
-Lastly, layer 8th zips FPM and pack everything ready for AWS Lambda.
+Lastly, layer 7 zips FPM and pack everything ready for AWS Lambda.
 
 ## Design decisions log
 

--- a/cpu-arm.Makefile
+++ b/cpu-arm.Makefile
@@ -17,6 +17,8 @@ everything: clean upload-layers upload-to-docker-hub
 docker-images:
 	# Prepare the content of `/opt` that will be copied in each layer
 	docker-compose -f ./layers/docker-compose.yml build --parallel
+	# Build images for "build environment"
+	docker-compose build --parallel build-php-80
 	# Build images for function layers
 	docker-compose build --parallel php-80
 	# Build images for FPM layers
@@ -55,11 +57,13 @@ upload-layers: layers
 # and re-upload them with the right tag.
 upload-to-docker-hub: docker-images
 	# Temporarily creating aliases of the Docker images to push to the test account
+	docker tag bref/arm-build-php-80 breftest/arm-build-php-80
 	docker tag bref/arm-php-80 breftest/arm-php-80
 	docker tag bref/arm-php-80-fpm breftest/arm-php-80-fpm
 	docker tag bref/arm-php-80-console breftest/arm-php-80-console
 
 	# TODO: change breftest/ to bref/
+	docker push breftest/arm-build-php-80
 	docker push breftest/arm-php-80
 	docker push breftest/arm-php-80-fpm
 	docker push breftest/arm-php-80-console
@@ -74,6 +78,7 @@ clean:
 	rm -f output/arm-*.zip
 	# Clean Docker images to force rebuilding them
 	docker image rm --force bref/arm-fpm-internal-src
+	docker image rm --force bref/arm-build-php-80
 	docker image rm --force bref/arm-php-80
 	docker image rm --force bref/arm-php-80-zip
 	docker image rm --force bref/arm-php-80-fpm

--- a/cpu-x86.Makefile
+++ b/cpu-x86.Makefile
@@ -17,6 +17,8 @@ everything: clean upload-layers upload-to-docker-hub
 docker-images:
 	# Prepare the content of `/opt` that will be copied in each layer
 	docker-compose -f ./layers/docker-compose.yml build --parallel
+	# Build images for "build environment"
+	docker-compose build --parallel build-php-80 build-php-81 build-php-82
 	# Build images for function layers
 	docker-compose build --parallel php-80 php-81 php-82
 	# Build images for FPM layers
@@ -64,21 +66,33 @@ upload-layers: layers
 # and re-upload them with the right tag.
 upload-to-docker-hub: docker-images
 	# Temporarily creating aliases of the Docker images to push to the test account
+	docker tag bref/build-php-80 breftest/build-php-80
+	docker tag bref/build-php-81 breftest/build-php-81
+	docker tag bref/build-php-82 breftest/build-php-82
 	docker tag bref/php-80 breftest/php-80
 	docker tag bref/php-81 breftest/php-81
+	docker tag bref/php-82 breftest/php-82
 	docker tag bref/php-80-fpm breftest/php-80-fpm
 	docker tag bref/php-81-fpm breftest/php-81-fpm
+	docker tag bref/php-82-fpm breftest/php-82-fpm
 	docker tag bref/php-80-console breftest/php-80-console
 	docker tag bref/php-81-console breftest/php-81-console
+	docker tag bref/php-82-console breftest/php-82-console
 	docker tag bref/fpm-dev-gateway breftest/fpm-dev-gateway
 
 	# TODO: change breftest/ to bref/
+	docker push breftest/build-php-80
+	docker push breftest/build-php-81
+	docker push breftest/build-php-82
 	docker push breftest/php-80
 	docker push breftest/php-81
+	docker push breftest/php-82
 	docker push breftest/php-80-fpm
 	docker push breftest/php-81-fpm
+	docker push breftest/php-82-fpm
 	docker push breftest/php-80-console
 	docker push breftest/php-81-console
+	docker push breftest/php-82-console
 	docker push breftest/fpm-dev-gateway
 
 
@@ -91,16 +105,24 @@ clean:
 	rm -f output/*.zip
 	# Clean Docker images to force rebuilding them
 	docker image rm --force bref/fpm-internal-src
+	docker image rm --force bref/build-php-80
+	docker image rm --force bref/build-php-81
+	docker image rm --force bref/build-php-82
 	docker image rm --force bref/php-80
-	docker image rm --force bref/php-80-zip
 	docker image rm --force bref/php-81
+	docker image rm --force bref/php-82
+	docker image rm --force bref/php-80-zip
 	docker image rm --force bref/php-81-zip
+	docker image rm --force bref/php-82-zip
 	docker image rm --force bref/php-80-fpm
-	docker image rm --force bref/php-80-fpm-zip
 	docker image rm --force bref/php-81-fpm
+	docker image rm --force bref/php-82-fpm
+	docker image rm --force bref/php-80-fpm-zip
 	docker image rm --force bref/php-81-fpm-zip
+	docker image rm --force bref/php-82-fpm-zip
 	docker image rm --force bref/php-80-console
 	docker image rm --force bref/php-81-console
+	docker image rm --force bref/php-82-console
 	docker image rm --force bref/fpm-dev-gateway
 	# Clear the build cache, else all images will be rebuilt using cached layers
 	docker builder prune

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,14 @@ services:
 
 #### PHP 8.0
 
+  build-php-80:
+    image: bref/build-${CPU_PREFIX}php-80
+    build:
+      context: .
+      dockerfile: php-80/cpu-${CPU}.Dockerfile
+      target: build-environment
+
+
   php-80:
     image: bref/${CPU_PREFIX}php-80
     build:
@@ -67,6 +75,14 @@ services:
 
 #### PHP 8.1
 
+  build-php-81:
+    image: bref/build-${CPU_PREFIX}php-81
+    build:
+      context: .
+      dockerfile: php-81/cpu-${CPU}.Dockerfile
+      target: build-environment
+
+
   php-81:
     image: bref/${CPU_PREFIX}php-81
     build:
@@ -116,6 +132,14 @@ services:
 
 
 #### PHP 8.2
+
+  build-php-82:
+    image: bref/build-${CPU_PREFIX}php-82
+    build:
+      context: .
+      dockerfile: php-82/cpu-${CPU}.Dockerfile
+      target: build-environment
+
 
   php-82:
     image: bref/${CPU_PREFIX}php-82

--- a/php-80/cpu-x86.Dockerfile
+++ b/php-80/cpu-x86.Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/provided:al2-x86_64 as binary
+FROM public.ecr.aws/lambda/provided:al2-x86_64 as build-environment
 
 # Specifying the exact PHP version lets us avoid the Docker cache when a new version comes out
 ENV VERSION_PHP=8.0.25-1
@@ -91,8 +91,6 @@ RUN cp /lib64/php/modules/curl.so /bref/bref/extensions/curl.so
 #RUN cp /lib64/libplc4.so /bref/lib/libplc4.so
 #RUN cp /lib64/libnspr4.so /bref/lib/libnspr4.so
 
-FROM binary as extensions
-
 RUN yum install -y --setopt=skip_missing_names_on_install=False \
     php-mbstring \
     php-bcmath \
@@ -115,6 +113,12 @@ RUN yum install -y --setopt=skip_missing_names_on_install=False \
     php-apcu \
     php-pdo_pgsql \
     php-zip
+
+# Install development tools to compile extra PHP extensions
+RUN yum groupinstall -y "Development Tools"
+RUN yum install -y --setopt=skip_missing_names_on_install=False \
+    php-devel \
+    php-pear
 
 RUN cp /lib64/php/modules/mbstring.so /bref/bref/extensions/mbstring.so
 RUN cp /usr/lib64/libonig.so.105 /bref/lib/libonig.so.105
@@ -148,9 +152,11 @@ RUN cp /usr/lib64/libzip.so.5 /bref/lib/libzip.so.5
 RUN cp /usr/lib64/libzstd.so.1 /bref/lib/libzstd.so.1
 RUN cp /lib64/php/modules/zip.so /bref/bref/extensions/zip.so
 
+# sodium
 RUN cp /lib64/php/modules/sodium.so /bref/bref/extensions/sodium.so
 RUN cp /usr/lib64/libsodium.so.23 /bref/lib/libsodium.so.23
 
+# other extensions without system dependencies
 RUN cp /lib64/php/modules/bcmath.so /bref/bref/extensions/bcmath.so
 RUN cp /lib64/php/modules/dom.so /bref/bref/extensions/dom.so
 RUN cp /lib64/php/modules/opcache.so /bref/bref/extensions/opcache.so
@@ -165,9 +171,10 @@ RUN cp /lib64/php/modules/xml.so /bref/bref/extensions/xml.so
 RUN cp /lib64/php/modules/xmlreader.so /bref/bref/extensions/xmlreader.so
 RUN cp /lib64/php/modules/xmlwriter.so /bref/bref/extensions/xmlwriter.so
 
+# Start from a clean image to copy only the files we need
 FROM public.ecr.aws/lambda/provided:al2-x86_64 as isolation
 
-COPY --from=extensions /bref /opt
+COPY --from=build-environment /bref /opt
 
 # This doesn't do anything on Lambda, but is useful when running via Docker (e.g. local dev)
 ENV PHP_INI_SCAN_DIR="/opt/bref/etc/php/conf.d:/var/task/php/conf.d"
@@ -199,7 +206,7 @@ RUN zip --quiet --recurse-paths /tmp/layer.zip .
 # packaged. Now we'll go back one step and start from the extensions so that we
 # can install fpm. Then we'll start the fpm layer and quickly isolate fpm.
 
-FROM extensions as fpm-extension
+FROM build-environment as fpm-extension
 
 RUN yum install -y php-fpm
 

--- a/php-82/cpu-x86.Dockerfile
+++ b/php-82/cpu-x86.Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/provided:al2-x86_64 as binary
+FROM public.ecr.aws/lambda/provided:al2-x86_64 as build-environment
 
 # Specifying the exact PHP version lets us avoid the Docker cache when a new version comes out
 ENV VERSION_PHP=8.2.0~RC6-7
@@ -92,8 +92,6 @@ RUN cp /lib64/php/modules/curl.so /bref/bref/extensions/curl.so
 #RUN cp /lib64/libplc4.so /bref/lib/libplc4.so
 #RUN cp /lib64/libnspr4.so /bref/lib/libnspr4.so
 
-FROM binary as extensions
-
 RUN yum install -y --setopt=skip_missing_names_on_install=False \
     php-mbstring \
     php-bcmath \
@@ -116,6 +114,12 @@ RUN yum install -y --setopt=skip_missing_names_on_install=False \
     php-apcu \
     php-pdo_pgsql \
     php-zip
+
+# Install development tools to compile extra PHP extensions
+RUN yum groupinstall -y "Development Tools"
+RUN yum install -y --setopt=skip_missing_names_on_install=False \
+    php-devel \
+    php-pear
 
 RUN cp /lib64/php/modules/mbstring.so /bref/bref/extensions/mbstring.so
 RUN cp /usr/lib64/libonig.so.105 /bref/lib/libonig.so.105
@@ -149,9 +153,11 @@ RUN cp /usr/lib64/libzip.so.5 /bref/lib/libzip.so.5
 RUN cp /usr/lib64/libzstd.so.1 /bref/lib/libzstd.so.1
 RUN cp /lib64/php/modules/zip.so /bref/bref/extensions/zip.so
 
+# sodium
 RUN cp /lib64/php/modules/sodium.so /bref/bref/extensions/sodium.so
 RUN cp /usr/lib64/libsodium.so.23 /bref/lib/libsodium.so.23
 
+# other extensions without system dependencies
 RUN cp /lib64/php/modules/bcmath.so /bref/bref/extensions/bcmath.so
 RUN cp /lib64/php/modules/dom.so /bref/bref/extensions/dom.so
 RUN cp /lib64/php/modules/opcache.so /bref/bref/extensions/opcache.so
@@ -166,9 +172,10 @@ RUN cp /lib64/php/modules/xml.so /bref/bref/extensions/xml.so
 RUN cp /lib64/php/modules/xmlreader.so /bref/bref/extensions/xmlreader.so
 RUN cp /lib64/php/modules/xmlwriter.so /bref/bref/extensions/xmlwriter.so
 
+# Start from a clean image to copy only the files we need
 FROM public.ecr.aws/lambda/provided:al2-x86_64 as isolation
 
-COPY --from=extensions /bref /opt
+COPY --from=build-environment /bref /opt
 
 # This doesn't do anything on Lambda, but is useful when running via Docker (e.g. local dev)
 ENV PHP_INI_SCAN_DIR="/opt/bref/etc/php/conf.d:/var/task/php/conf.d"
@@ -200,7 +207,7 @@ RUN zip --quiet --recurse-paths /tmp/layer.zip .
 # packaged. Now we'll go back one step and start from the extensions so that we
 # can install fpm. Then we'll start the fpm layer and quickly isolate fpm.
 
-FROM extensions as fpm-extension
+FROM build-environment as fpm-extension
 
 RUN yum install -y php-fpm
 


### PR DESCRIPTION
This provides the `bref/build-php-80` images used to compile extra extensions.

Check out #31 for a bit more context.
