### PR TITLE
Optimize the build by publishing a "base-devel" image ahead of time

### DIFF
--- a/.github/workflows/release-base-devel-image.yml
+++ b/.github/workflows/release-base-devel-image.yml
@@ -1,0 +1,21 @@
+name: Update the base-devel image once a week
+
+on:
+    # This workflow can be manually triggered
+    workflow_dispatch:
+    schedule:
+        # Once a week
+        -   cron: '0 0 * * 0'
+
+jobs:
+    publish-base-devel:
+        name: Build and publish base-devel
+        runs-on: ubuntu-latest
+        steps:
+            -   uses: actions/checkout@v3
+            -   name: Log in to Docker Hub
+                uses: docker/login-action@v2
+                with:
+                    username: ${{ secrets.DOCKER_USERNAME }}
+                    password: ${{ secrets.DOCKER_PASSWORD }}
+            -   run: cd base-devel && make upload-to-docker-hub

--- a/base-devel/Makefile
+++ b/base-devel/Makefile
@@ -1,0 +1,8 @@
+build:
+	docker-compose build --parallel
+
+upload-to-docker-hub: build
+	docker tag bref/base-devel-arm bref/base-devel-arm
+	docker tag bref/base-devel-x86 bref/base-devel-x86
+	docker push bref/base-devel-arm
+	docker push bref/base-devel-x86

--- a/base-devel/README.md
+++ b/base-devel/README.md
@@ -1,0 +1,5 @@
+These images provide Amazon Linux 2 images with some packages pre-installed.
+
+These packages are the same for all layers, and we don't need to rebuild everything every time we build layers. So to optimize the builds, we build these base layers once (every now and then) and publish them to Docker Hub.
+
+Then the layers build can use the published versions without having to rebuild them every time. That accelerates the build process.

--- a/base-devel/cpu-arm.Dockerfile
+++ b/base-devel/cpu-arm.Dockerfile
@@ -1,0 +1,6 @@
+FROM public.ecr.aws/lambda/provided:al2-arm64
+
+RUN yum install -y unzip curl
+
+# Install development tools to compile extra PHP extensions
+RUN yum groupinstall -y "Development Tools"

--- a/base-devel/cpu-x86.Dockerfile
+++ b/base-devel/cpu-x86.Dockerfile
@@ -1,0 +1,12 @@
+FROM public.ecr.aws/lambda/provided:al2-x86_64
+
+# yum-utils installs the yum-config-manager command
+RUN yum install -y \
+        https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
+        https://rpms.remirepo.net/enterprise/remi-release-7.rpm \
+        yum-utils \
+        epel-release \
+        curl
+
+# Install development tools to compile extra PHP extensions
+RUN yum groupinstall -y "Development Tools"

--- a/base-devel/docker-compose.yml
+++ b/base-devel/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.8'
+
+services:
+
+  arm:
+    image: bref/base-devel-arm
+    build:
+      context: .
+      dockerfile: cpu-arm.Dockerfile
+
+  x86:
+    image: bref/base-devel-x86
+    build:
+      context: .
+      dockerfile: cpu-x86.Dockerfile

--- a/php-80/cpu-arm.Dockerfile
+++ b/php-80/cpu-arm.Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/provided:al2-arm64 as build-environment
+FROM bref/base-devel-arm as build-environment
 
 # Specifying the exact PHP version lets us avoid the Docker cache when a new version comes out
 ENV VERSION_PHP=8.0.25-1
@@ -19,7 +19,7 @@ RUN amazon-linux-extras enable php8.0
 
 # --setopt=skip_missing_names_on_install=False makes sure we get an error if a package is missing
 RUN yum install --setopt=skip_missing_names_on_install=False -y \
-        php-cli-${VERSION_PHP}.amzn2 unzip curl
+        php-cli-${VERSION_PHP}.amzn2
 
 # These files are included on Amazon Linux 2
 
@@ -105,7 +105,6 @@ RUN yum install -y --setopt=skip_missing_names_on_install=False \
     php-zip
 
 # Install development tools to compile extra PHP extensions
-RUN yum groupinstall -y "Development Tools"
 RUN yum install -y --setopt=skip_missing_names_on_install=False \
     php-devel \
     php-pear

--- a/php-80/cpu-x86.Dockerfile
+++ b/php-80/cpu-x86.Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/provided:al2-x86_64 as build-environment
+FROM bref/base-devel-x86 as build-environment
 
 # Specifying the exact PHP version lets us avoid the Docker cache when a new version comes out
 ENV VERSION_PHP=8.0.25-1
@@ -12,14 +12,6 @@ RUN mkdir /bref \
 &&  mkdir /bref/bin \
 &&  mkdir /bref/lib \
 &&  mkdir -p /bref/bref/extensions
-
-# yum-utils installs the yum-config-manager command
-RUN yum install -y \
-        https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
-        https://rpms.remirepo.net/enterprise/remi-release-7.rpm \
-        yum-utils \
-        epel-release \
-        curl
 
 RUN yum-config-manager --enable remi-php80
 
@@ -115,7 +107,6 @@ RUN yum install -y --setopt=skip_missing_names_on_install=False \
     php-zip
 
 # Install development tools to compile extra PHP extensions
-RUN yum groupinstall -y "Development Tools"
 RUN yum install -y --setopt=skip_missing_names_on_install=False \
     php-devel \
     php-pear

--- a/php-81/cpu-x86.Dockerfile
+++ b/php-81/cpu-x86.Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/provided:al2-x86_64 as build-environment
+FROM bref/base-devel-x86 as build-environment
 
 # Specifying the exact PHP version lets us avoid the Docker cache when a new version comes out
 ENV VERSION_PHP=8.1.12-1
@@ -12,14 +12,6 @@ RUN mkdir /bref \
 &&  mkdir /bref/bin \
 &&  mkdir /bref/lib \
 &&  mkdir -p /bref/bref/extensions
-
-# yum-utils installs the yum-config-manager command
-RUN yum install -y \
-        https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
-        https://rpms.remirepo.net/enterprise/remi-release-7.rpm \
-        yum-utils \
-        epel-release \
-        curl
 
 RUN yum-config-manager --enable remi-php81
 
@@ -115,7 +107,6 @@ RUN yum install -y --setopt=skip_missing_names_on_install=False \
     php-zip
 
 # Install development tools to compile extra PHP extensions
-RUN yum groupinstall -y "Development Tools"
 RUN yum install -y --setopt=skip_missing_names_on_install=False \
     php-devel \
     php-pear

--- a/php-82/cpu-x86.Dockerfile
+++ b/php-82/cpu-x86.Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/provided:al2-x86_64 as build-environment
+FROM bref/base-devel-x86 as build-environment
 
 # Specifying the exact PHP version lets us avoid the Docker cache when a new version comes out
 ENV VERSION_PHP=8.2.0~RC6-7
@@ -13,14 +13,6 @@ RUN mkdir /bref \
 &&  mkdir /bref/bin \
 &&  mkdir /bref/lib \
 &&  mkdir -p /bref/bref/extensions
-
-# yum-utils installs the yum-config-manager command
-RUN yum install -y \
-        https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
-        https://rpms.remirepo.net/enterprise/remi-release-7.rpm \
-        yum-utils \
-        epel-release \
-        curl
 
 RUN yum-config-manager --enable remi-php82
 
@@ -116,7 +108,6 @@ RUN yum install -y --setopt=skip_missing_names_on_install=False \
     php-zip
 
 # Install development tools to compile extra PHP extensions
-RUN yum groupinstall -y "Development Tools"
 RUN yum install -y --setopt=skip_missing_names_on_install=False \
     php-devel \
     php-pear


### PR DESCRIPTION
This introduces new `bref/base-devel-x86` and `bref/base-devel-arm` images that are built asynchronously (every week).

These images pre-install Amazon Linux dev tools, so that this expensive operation isn't performed when we actually build the layers. Since these operations are not related to the PHP version, or every the current day (i.e. those are basic system installs), we can run these asynchronously and hopefully accelerate the builds.