### PR TITLE
Use local buildx for third-party PR builds

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,8 @@ jobs:
     tests:
         name: Build and tests PHP ${{ matrix.php_version }}, ${{ matrix.cpu }}
         runs-on: ubuntu-latest
+        # Skip ARM builds on third-party pull requests, because they don't have access to Depot
+        if: matrix.cpu != 'arm' || github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         strategy:
             fail-fast: false
             matrix:
@@ -34,6 +36,7 @@ jobs:
                 uses: docker/setup-qemu-action@v2
 
             -   uses: depot/setup-action@v1
+            -   uses: docker/setup-buildx-action@v2
 
             # We use this action instead of running `make docker-images-php-XX` directly because it lets us
             # use OIDC authentication instead of a secret. Secrets can't be used in pull request builds.
@@ -41,6 +44,8 @@ jobs:
                 uses: depot/bake-action@v1
                 with:
                     load: true
+                    # If this is an third-party pull request, fall back to the local buildx builder
+                    buildx-fallback: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
                 env:
                     CPU: ${{ matrix.cpu }}
                     CPU_PREFIX: ${{ (matrix.cpu == 'arm') && 'arm-' || '' }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,21 +13,38 @@ permissions:
     contents: read
 
 jobs:
+    matrix-prep:
+        name: Prepare matrix
+        runs-on: ubuntu-latest
+        outputs:
+            matrix: ${{ steps.set-matrix.outputs.result }}
+        steps:
+            -   uses: actions/github-script@v6
+                id: set-matrix
+                with:
+                    script: |
+                        const matrix = {
+                            cpu: ['x86', 'arm'],
+                            php_version: ['80', '81', '82'],
+                        }
+                        
+                        // If this is a third-party pull request, skip ARM builds
+                        if (context.eventName === 'pull_request') {
+                            const pr = context.payload.pull_request
+                            if (pr.head.repo.full_name !== pr.base.repo.full_name) {
+                                matrix.cpu = ['x86']
+                            }
+                        }
+                        
+                        return matrix
+
     tests:
         name: Build and tests PHP ${{ matrix.php_version }}, ${{ matrix.cpu }}
         runs-on: ubuntu-latest
-        # Skip ARM builds on third-party pull requests, because they don't have access to Depot
-        if: matrix.cpu != 'arm' || github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        needs: matrix-prep
         strategy:
             fail-fast: false
-            matrix:
-                cpu:
-                    - x86
-                    - arm
-                php_version:
-                    - 80
-                    - 81
-                    - 82
+            matrix: ${{ fromJson(needs.matrix-prep.outputs.matrix) }}
         steps:
             -   uses: actions/checkout@v3
 


### PR DESCRIPTION
This should fix the failure seen in #47. 

This is an annoying GitHub limitation - GitHub blocks access to all repository secrets and the OIDC token endpoint for PRs that originate from fork repos. This is a security feature, to prevent PRs from exfiltrating secrets, but also means there's no way at the moment to authenticate with your Depot builder. Workflows for `push` work, and workflows for `pull_request`s work if they originate from within this repo, just not from forks.

We have a few ideas we've been exploring for how to work around this limitation, and we're trying to get in touch with GitHub as well to see if there's a better long-term solution, but in the meantime, our recommended workaround is to fall back to local `buildx bake` for fork PRs.

This PR modifies the tests workflow to do two things:

1. Only build for ARM on `push` event or if the `pull_request` originates from within this repo (so for third-party PRs from forks, ARM is skipped)
2. For third-party PRs from forks, it falls back to running the build using local `docker buildx bake`

You technically could keep ARM builds in there, but they are _really slow_ with QEMU as you know, so we usually recommend leaving them disabled for PRs from forks.