### PR TITLE
Fix missing libraries bundled in layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ docker run --rm -it --entrypoint=bash bref/php-80
 > 
 > `ldd` is a linux utility that will show libraries (`.so` files) used by a binary/library. For example: `ldd /opt/bin/php` or `ldd /opt/bref/extensions/curl.so`. That helps to make sure we include all the libraries needed by PHP extensions in the layers.
 > 
-> However, `ldd` fails when running on another CPU architecture. So instead of `ldd`, we can use `objdump -p /usr/bin/bash | grep NEEDED` (that needs to be installed with `yum install binutils`).
+> However, `ldd` fails when running on another CPU architecture. So instead of `ldd`, we can use `LD_TRACE_LOADED_OBJECTS=1 /opt/bin/php` (see https://stackoverflow.com/a/35905007/245552).
 
 ### Supporting a new PHP version
 

--- a/php-80/Dockerfile
+++ b/php-80/Dockerfile
@@ -16,14 +16,10 @@ ARG VERSION_PHP=8.0.27
 FROM public.ecr.aws/lambda/provided:al2-${IMAGE_VERSION_SUFFIX} as build-environment
 
 
-# Temp directory in which all compilation happens
-WORKDIR /tmp
-
-
 RUN set -xe \
     # Download yum repository data to cache
  && yum makecache \
-    # Default Development Tools
+    # Install default development tools (gcc, make, etc)
  && yum groupinstall -y "Development Tools" --setopt=group_package_types=mandatory,default
 
 
@@ -42,8 +38,15 @@ SHELL ["/bin/bash", "-c"]
 # We need a base path for all the sourcecode we will build from.
 ENV BUILD_DIR="/tmp/build"
 
-# Target installation path for all the packages we will compile
-ENV INSTALL_DIR="/tmp/bref"
+# Target installation path for all the binaries and libraries we will compile.
+# We need to use /opt because that's where AWS Lambda layers are unzipped,
+# and we need binaries (e.g. /opt/bin/php) to look for libraries in /opt/lib.
+# Indeed, `/opt/lib` is a path Lambda looks for libraries by default (it is in `LD_LIBRARY_PATH`)
+# AND the `/opt/lib` path will be hardcoded in the compiled binaries and libraries (called "rpath").
+#
+# Note: the /opt directory will be completely recreated from scratch in the final images,
+# so it's ok at this stage if we "pollute" it with plenty of extra libs/build artifacts.
+ENV INSTALL_DIR="/opt"
 
 # We need some default compiler variables setup
 ENV PKG_CONFIG_PATH="${INSTALL_DIR}/lib64/pkgconfig:${INSTALL_DIR}/lib/pkgconfig" \
@@ -413,35 +416,36 @@ RUN pecl install APCu
 
 
 # ---------------------------------------------------------------
-# Now we copy everything we need for the layers into /opt (location of the layers)
-RUN mkdir /opt/bin \
-&&  mkdir /opt/lib \
-&&  mkdir -p /opt/bref/extensions
+# Now we copy everything we need for the layers into /bref-layer (which will be used for the real /opt later)
+RUN mkdir -p /bref-layer/bin \
+&&  mkdir -p /bref-layer/lib \
+&&  mkdir -p /bref-layer/bref/extensions
 
-# Copy the PHP binary into /opt/bin
-RUN cp ${INSTALL_DIR}/bin/php /opt/bin/php && chmod +x /opt/bin/php
+# Copy the PHP binary
+RUN cp ${INSTALL_DIR}/bin/php /bref-layer/bin/php && chmod +x /bref-layer/bin/php
 
 # Copy all the external PHP extensions
-RUN cp $(php -r 'echo ini_get("extension_dir");')/* /opt/bref/extensions/
+RUN cp $(php -r 'echo ini_get("extension_dir");')/* /bref-layer/bref/extensions/
 
 # Copy all the required system libraries from:
 # - /lib | /lib64 (system libraries installed with `yum`)
-# - /tmp/bref/bin | /tmp/bref/lib | /tmp/bref/lib64 (libraries compiled from source)
-# into `/opt` (the directory of Lambda layers)
+# - /opt/bin | /opt/lib | /opt/lib64 (libraries compiled from source)
+# into `/bref-layer` (the temp directory for the future Lambda layer)
 COPY --link utils/lib-copy /bref/lib-copy
-RUN php /bref/lib-copy/copy-dependencies.php /opt/bin/php /opt/lib
-RUN php /bref/lib-copy/copy-dependencies.php /opt/bref/extensions/apcu.so /opt/lib
-RUN php /bref/lib-copy/copy-dependencies.php /opt/bref/extensions/intl.so /opt/lib
-RUN php /bref/lib-copy/copy-dependencies.php /opt/bref/extensions/opcache.so /opt/lib
-RUN php /bref/lib-copy/copy-dependencies.php /opt/bref/extensions/pdo_mysql.so /opt/lib
-RUN php /bref/lib-copy/copy-dependencies.php /opt/bref/extensions/pdo_pgsql.so /opt/lib
+RUN php /bref/lib-copy/copy-dependencies.php /bref-layer/bin/php /bref-layer/lib
+RUN php /bref/lib-copy/copy-dependencies.php /bref-layer/bref/extensions/apcu.so /bref-layer/lib
+RUN php /bref/lib-copy/copy-dependencies.php /bref-layer/bref/extensions/intl.so /bref-layer/lib
+RUN php /bref/lib-copy/copy-dependencies.php /bref-layer/bref/extensions/opcache.so /bref-layer/lib
+RUN php /bref/lib-copy/copy-dependencies.php /bref-layer/bref/extensions/pdo_mysql.so /bref-layer/lib
+RUN php /bref/lib-copy/copy-dependencies.php /bref-layer/bref/extensions/pdo_pgsql.so /bref-layer/lib
 
 
 # ---------------------------------------------------------------
 # Start from a clean image to copy only the files we need
 FROM public.ecr.aws/lambda/provided:al2-${IMAGE_VERSION_SUFFIX} as isolation
 
-COPY --link --from=build-environment /opt /opt
+# We selected the files in /bref-layer, now we copy them to /opt (the real directory for the Lambda layer)
+COPY --link --from=build-environment /bref-layer /opt
 
 FROM isolation as function
 
@@ -462,15 +466,15 @@ COPY --link layers/function/bootstrap.php /opt/bref/bootstrap.php
 
 FROM build-environment as fpm-extension
 
-RUN cp ${INSTALL_DIR}/sbin/php-fpm /opt/bin/php-fpm
-RUN php /bref/lib-copy/copy-dependencies.php /opt/bin/php-fpm /opt/lib
+RUN cp ${INSTALL_DIR}/sbin/php-fpm /bref-layer/bin/php-fpm
+RUN php /bref/lib-copy/copy-dependencies.php /bref-layer/bin/php-fpm /bref-layer/lib
 
 
 # Embed the https://github.com/brefphp/php-fpm-runtime in the layer
 FROM composer:2 as fpm-runtime
 
-RUN mkdir -p /opt/bref/php-fpm-runtime
-WORKDIR /opt/bref/php-fpm-runtime
+RUN mkdir -p /bref-layer/bref/php-fpm-runtime
+WORKDIR /bref-layer/bref/php-fpm-runtime
 
 COPY --link layers/fpm/composer.json composer.json
 RUN composer install --ignore-platform-req=ext-posix --ignore-platform-req=ext-simplexml
@@ -478,7 +482,7 @@ RUN composer install --ignore-platform-req=ext-posix --ignore-platform-req=ext-s
 
 FROM isolation as fpm
 
-COPY --link --from=fpm-extension /opt /opt
+COPY --link --from=fpm-extension /bref-layer /opt
 
 COPY --link layers/fpm/bref.ini /opt/bref/etc/php/conf.d/
 
@@ -489,4 +493,4 @@ RUN chmod +x /opt/bootstrap && chmod +x /var/runtime/bootstrap
 
 COPY --link layers/fpm/php-fpm.conf /opt/bref/etc/php-fpm.conf
 
-COPY --link --from=fpm-runtime /opt/bref/php-fpm-runtime /opt/bref/php-fpm-runtime
+COPY --link --from=fpm-runtime /bref-layer/bref/php-fpm-runtime /opt/bref/php-fpm-runtime

--- a/php-81/Dockerfile
+++ b/php-81/Dockerfile
@@ -16,14 +16,10 @@ ARG VERSION_PHP=8.1.15
 FROM public.ecr.aws/lambda/provided:al2-${IMAGE_VERSION_SUFFIX} as build-environment
 
 
-# Temp directory in which all compilation happens
-WORKDIR /tmp
-
-
 RUN set -xe \
     # Download yum repository data to cache
  && yum makecache \
-    # Default Development Tools
+    # Install default development tools (gcc, make, etc)
  && yum groupinstall -y "Development Tools" --setopt=group_package_types=mandatory,default
 
 
@@ -42,8 +38,15 @@ SHELL ["/bin/bash", "-c"]
 # We need a base path for all the sourcecode we will build from.
 ENV BUILD_DIR="/tmp/build"
 
-# Target installation path for all the packages we will compile
-ENV INSTALL_DIR="/tmp/bref"
+# Target installation path for all the binaries and libraries we will compile.
+# We need to use /opt because that's where AWS Lambda layers are unzipped,
+# and we need binaries (e.g. /opt/bin/php) to look for libraries in /opt/lib.
+# Indeed, `/opt/lib` is a path Lambda looks for libraries by default (it is in `LD_LIBRARY_PATH`)
+# AND the `/opt/lib` path will be hardcoded in the compiled binaries and libraries (called "rpath").
+#
+# Note: the /opt directory will be completely recreated from scratch in the final images,
+# so it's ok at this stage if we "pollute" it with plenty of extra libs/build artifacts.
+ENV INSTALL_DIR="/opt"
 
 # We need some default compiler variables setup
 ENV PKG_CONFIG_PATH="${INSTALL_DIR}/lib64/pkgconfig:${INSTALL_DIR}/lib/pkgconfig" \
@@ -413,35 +416,36 @@ RUN pecl install APCu
 
 
 # ---------------------------------------------------------------
-# Now we copy everything we need for the layers into /opt (location of the layers)
-RUN mkdir /opt/bin \
-&&  mkdir /opt/lib \
-&&  mkdir -p /opt/bref/extensions
+# Now we copy everything we need for the layers into /bref-layer (which will be used for the real /opt later)
+RUN mkdir -p /bref-layer/bin \
+&&  mkdir -p /bref-layer/lib \
+&&  mkdir -p /bref-layer/bref/extensions
 
-# Copy the PHP binary into /opt/bin
-RUN cp ${INSTALL_DIR}/bin/php /opt/bin/php && chmod +x /opt/bin/php
+# Copy the PHP binary
+RUN cp ${INSTALL_DIR}/bin/php /bref-layer/bin/php && chmod +x /bref-layer/bin/php
 
 # Copy all the external PHP extensions
-RUN cp $(php -r 'echo ini_get("extension_dir");')/* /opt/bref/extensions/
+RUN cp $(php -r 'echo ini_get("extension_dir");')/* /bref-layer/bref/extensions/
 
 # Copy all the required system libraries from:
 # - /lib | /lib64 (system libraries installed with `yum`)
-# - /tmp/bref/bin | /tmp/bref/lib | /tmp/bref/lib64 (libraries compiled from source)
-# into `/opt` (the directory of Lambda layers)
+# - /opt/bin | /opt/lib | /opt/lib64 (libraries compiled from source)
+# into `/bref-layer` (the temp directory for the future Lambda layer)
 COPY --link utils/lib-copy /bref/lib-copy
-RUN php /bref/lib-copy/copy-dependencies.php /opt/bin/php /opt/lib
-RUN php /bref/lib-copy/copy-dependencies.php /opt/bref/extensions/apcu.so /opt/lib
-RUN php /bref/lib-copy/copy-dependencies.php /opt/bref/extensions/intl.so /opt/lib
-RUN php /bref/lib-copy/copy-dependencies.php /opt/bref/extensions/opcache.so /opt/lib
-RUN php /bref/lib-copy/copy-dependencies.php /opt/bref/extensions/pdo_mysql.so /opt/lib
-RUN php /bref/lib-copy/copy-dependencies.php /opt/bref/extensions/pdo_pgsql.so /opt/lib
+RUN php /bref/lib-copy/copy-dependencies.php /bref-layer/bin/php /bref-layer/lib
+RUN php /bref/lib-copy/copy-dependencies.php /bref-layer/bref/extensions/apcu.so /bref-layer/lib
+RUN php /bref/lib-copy/copy-dependencies.php /bref-layer/bref/extensions/intl.so /bref-layer/lib
+RUN php /bref/lib-copy/copy-dependencies.php /bref-layer/bref/extensions/opcache.so /bref-layer/lib
+RUN php /bref/lib-copy/copy-dependencies.php /bref-layer/bref/extensions/pdo_mysql.so /bref-layer/lib
+RUN php /bref/lib-copy/copy-dependencies.php /bref-layer/bref/extensions/pdo_pgsql.so /bref-layer/lib
 
 
 # ---------------------------------------------------------------
 # Start from a clean image to copy only the files we need
 FROM public.ecr.aws/lambda/provided:al2-${IMAGE_VERSION_SUFFIX} as isolation
 
-COPY --link --from=build-environment /opt /opt
+# We selected the files in /bref-layer, now we copy them to /opt (the real directory for the Lambda layer)
+COPY --link --from=build-environment /bref-layer /opt
 
 FROM isolation as function
 
@@ -462,15 +466,15 @@ COPY --link layers/function/bootstrap.php /opt/bref/bootstrap.php
 
 FROM build-environment as fpm-extension
 
-RUN cp ${INSTALL_DIR}/sbin/php-fpm /opt/bin/php-fpm
-RUN php /bref/lib-copy/copy-dependencies.php /opt/bin/php-fpm /opt/lib
+RUN cp ${INSTALL_DIR}/sbin/php-fpm /bref-layer/bin/php-fpm
+RUN php /bref/lib-copy/copy-dependencies.php /bref-layer/bin/php-fpm /bref-layer/lib
 
 
 # Embed the https://github.com/brefphp/php-fpm-runtime in the layer
 FROM composer:2 as fpm-runtime
 
-RUN mkdir -p /opt/bref/php-fpm-runtime
-WORKDIR /opt/bref/php-fpm-runtime
+RUN mkdir -p /bref-layer/bref/php-fpm-runtime
+WORKDIR /bref-layer/bref/php-fpm-runtime
 
 COPY --link layers/fpm/composer.json composer.json
 RUN composer install --ignore-platform-req=ext-posix --ignore-platform-req=ext-simplexml
@@ -478,7 +482,7 @@ RUN composer install --ignore-platform-req=ext-posix --ignore-platform-req=ext-s
 
 FROM isolation as fpm
 
-COPY --link --from=fpm-extension /opt /opt
+COPY --link --from=fpm-extension /bref-layer /opt
 
 COPY --link layers/fpm/bref.ini /opt/bref/etc/php/conf.d/
 
@@ -489,4 +493,4 @@ RUN chmod +x /opt/bootstrap && chmod +x /var/runtime/bootstrap
 
 COPY --link layers/fpm/php-fpm.conf /opt/bref/etc/php-fpm.conf
 
-COPY --link --from=fpm-runtime /opt/bref/php-fpm-runtime /opt/bref/php-fpm-runtime
+COPY --link --from=fpm-runtime /bref-layer/bref/php-fpm-runtime /opt/bref/php-fpm-runtime

--- a/php-82/Dockerfile
+++ b/php-82/Dockerfile
@@ -16,14 +16,10 @@ ARG VERSION_PHP=8.2.2
 FROM public.ecr.aws/lambda/provided:al2-${IMAGE_VERSION_SUFFIX} as build-environment
 
 
-# Temp directory in which all compilation happens
-WORKDIR /tmp
-
-
 RUN set -xe \
     # Download yum repository data to cache
  && yum makecache \
-    # Default Development Tools
+    # Install default development tools (gcc, make, etc)
  && yum groupinstall -y "Development Tools" --setopt=group_package_types=mandatory,default
 
 
@@ -35,6 +31,7 @@ RUN LD_LIBRARY_PATH= yum install -y cmake3
 # Override the default `cmake`
 RUN ln -s /usr/bin/cmake3 /usr/bin/cmake
 
+
 # Use the bash shell, instead of /bin/sh
 # Why? We need to document this.
 SHELL ["/bin/bash", "-c"]
@@ -42,8 +39,15 @@ SHELL ["/bin/bash", "-c"]
 # We need a base path for all the sourcecode we will build from.
 ENV BUILD_DIR="/tmp/build"
 
-# Target installation path for all the packages we will compile
-ENV INSTALL_DIR="/tmp/bref"
+# Target installation path for all the binaries and libraries we will compile.
+# We need to use /opt because that's where AWS Lambda layers are unzipped,
+# and we need binaries (e.g. /opt/bin/php) to look for libraries in /opt/lib.
+# Indeed, `/opt/lib` is a path Lambda looks for libraries by default (it is in `LD_LIBRARY_PATH`)
+# AND the `/opt/lib` path will be hardcoded in the compiled binaries and libraries (called "rpath").
+#
+# Note: the /opt directory will be completely recreated from scratch in the final images,
+# so it's ok at this stage if we "pollute" it with plenty of extra libs/build artifacts.
+ENV INSTALL_DIR="/opt"
 
 # We need some default compiler variables setup
 ENV PKG_CONFIG_PATH="${INSTALL_DIR}/lib64/pkgconfig:${INSTALL_DIR}/lib/pkgconfig" \
@@ -413,35 +417,36 @@ RUN pecl install APCu
 
 
 # ---------------------------------------------------------------
-# Now we copy everything we need for the layers into /opt (location of the layers)
-RUN mkdir /opt/bin \
-&&  mkdir /opt/lib \
-&&  mkdir -p /opt/bref/extensions
+# Now we copy everything we need for the layers into /bref-layer (which will be used for the real /opt later)
+RUN mkdir -p /bref-layer/bin \
+&&  mkdir -p /bref-layer/lib \
+&&  mkdir -p /bref-layer/bref/extensions
 
-# Copy the PHP binary into /opt/bin
-RUN cp ${INSTALL_DIR}/bin/php /opt/bin/php && chmod +x /opt/bin/php
+# Copy the PHP binary
+RUN cp ${INSTALL_DIR}/bin/php /bref-layer/bin/php && chmod +x /bref-layer/bin/php
 
 # Copy all the external PHP extensions
-RUN cp $(php -r 'echo ini_get("extension_dir");')/* /opt/bref/extensions/
+RUN cp $(php -r 'echo ini_get("extension_dir");')/* /bref-layer/bref/extensions/
 
 # Copy all the required system libraries from:
 # - /lib | /lib64 (system libraries installed with `yum`)
-# - /tmp/bref/bin | /tmp/bref/lib | /tmp/bref/lib64 (libraries compiled from source)
-# into `/opt` (the directory of Lambda layers)
+# - /opt/bin | /opt/lib | /opt/lib64 (libraries compiled from source)
+# into `/bref-layer` (the temp directory for the future Lambda layer)
 COPY --link utils/lib-copy /bref/lib-copy
-RUN php /bref/lib-copy/copy-dependencies.php /opt/bin/php /opt/lib
-RUN php /bref/lib-copy/copy-dependencies.php /opt/bref/extensions/apcu.so /opt/lib
-RUN php /bref/lib-copy/copy-dependencies.php /opt/bref/extensions/intl.so /opt/lib
-RUN php /bref/lib-copy/copy-dependencies.php /opt/bref/extensions/opcache.so /opt/lib
-RUN php /bref/lib-copy/copy-dependencies.php /opt/bref/extensions/pdo_mysql.so /opt/lib
-RUN php /bref/lib-copy/copy-dependencies.php /opt/bref/extensions/pdo_pgsql.so /opt/lib
+RUN php /bref/lib-copy/copy-dependencies.php /bref-layer/bin/php /bref-layer/lib
+RUN php /bref/lib-copy/copy-dependencies.php /bref-layer/bref/extensions/apcu.so /bref-layer/lib
+RUN php /bref/lib-copy/copy-dependencies.php /bref-layer/bref/extensions/intl.so /bref-layer/lib
+RUN php /bref/lib-copy/copy-dependencies.php /bref-layer/bref/extensions/opcache.so /bref-layer/lib
+RUN php /bref/lib-copy/copy-dependencies.php /bref-layer/bref/extensions/pdo_mysql.so /bref-layer/lib
+RUN php /bref/lib-copy/copy-dependencies.php /bref-layer/bref/extensions/pdo_pgsql.so /bref-layer/lib
 
 
 # ---------------------------------------------------------------
 # Start from a clean image to copy only the files we need
 FROM public.ecr.aws/lambda/provided:al2-${IMAGE_VERSION_SUFFIX} as isolation
 
-COPY --link --from=build-environment /opt /opt
+# We selected the files in /bref-layer, now we copy them to /opt (the real directory for the Lambda layer)
+COPY --link --from=build-environment /bref-layer /opt
 
 FROM isolation as function
 
@@ -462,15 +467,15 @@ COPY --link layers/function/bootstrap.php /opt/bref/bootstrap.php
 
 FROM build-environment as fpm-extension
 
-RUN cp ${INSTALL_DIR}/sbin/php-fpm /opt/bin/php-fpm
-RUN php /bref/lib-copy/copy-dependencies.php /opt/bin/php-fpm /opt/lib
+RUN cp ${INSTALL_DIR}/sbin/php-fpm /bref-layer/bin/php-fpm
+RUN php /bref/lib-copy/copy-dependencies.php /bref-layer/bin/php-fpm /bref-layer/lib
 
 
 # Embed the https://github.com/brefphp/php-fpm-runtime in the layer
 FROM composer:2 as fpm-runtime
 
-RUN mkdir -p /opt/bref/php-fpm-runtime
-WORKDIR /opt/bref/php-fpm-runtime
+RUN mkdir -p /bref-layer/bref/php-fpm-runtime
+WORKDIR /bref-layer/bref/php-fpm-runtime
 
 COPY --link layers/fpm/composer.json composer.json
 RUN composer install --ignore-platform-req=ext-posix --ignore-platform-req=ext-simplexml
@@ -478,7 +483,7 @@ RUN composer install --ignore-platform-req=ext-posix --ignore-platform-req=ext-s
 
 FROM isolation as fpm
 
-COPY --link --from=fpm-extension /opt /opt
+COPY --link --from=fpm-extension /bref-layer /opt
 
 COPY --link layers/fpm/bref.ini /opt/bref/etc/php/conf.d/
 
@@ -489,4 +494,4 @@ RUN chmod +x /opt/bootstrap && chmod +x /var/runtime/bootstrap
 
 COPY --link layers/fpm/php-fpm.conf /opt/bref/etc/php-fpm.conf
 
-COPY --link --from=fpm-runtime /opt/bref/php-fpm-runtime /opt/bref/php-fpm-runtime
+COPY --link --from=fpm-runtime /bref-layer/bref/php-fpm-runtime /opt/bref/php-fpm-runtime

--- a/tests/test_2_extensions.php
+++ b/tests/test_2_extensions.php
@@ -77,7 +77,7 @@ foreach ($coreExtensions as $extension => $test) {
 $extensions = [
     'curl' => function_exists('curl_init')
         // Make sure we are not using the default AL2 cURL version (7.79)
-        && version_compare(curl_version()['version'], '7.85.0', '>='),
+        && version_compare(curl_version()['version'], '7.84.0', '>='),
     // https://github.com/brefphp/aws-lambda-layers/issues/42
     'curl-http2' => defined('CURL_HTTP_VERSION_2'),
     // Make sure we are not using the default AL2 OpenSSL version (7.79)

--- a/tests/utils.php
+++ b/tests/utils.php
@@ -13,3 +13,15 @@ function success(string $message): void
     echo "\033[31m⨯ $message\033[0m" . PHP_EOL;
     exit(1);
 }
+
+/**
+ * @param string[] $messages
+ * @return never-return
+ */
+#[NoReturn] function errors(array $messages): void
+{
+    foreach ($messages as $message) {
+        echo "\033[31m⨯ $message\033[0m" . PHP_EOL;
+    }
+    exit(1);
+}

--- a/utils/lib-copy/copy-dependencies.php
+++ b/utils/lib-copy/copy-dependencies.php
@@ -37,7 +37,9 @@ $librariesThatExistOnLambda = array_filter($librariesThatExistOnLambda, function
 $requiredLibraries = listDependencies($pathToCheck);
 // Exclude existing system libraries
 $requiredLibraries = array_filter($requiredLibraries, function (string $lib) use ($librariesThatExistOnLambda) {
-    $isALibraryWeCompiled = str_starts_with($lib, '/tmp/bref/lib');
+    // Libraries that we compiled are in /opt/lib or /opt/lib64, we compiled them because they are more
+    // recent than the ones in Lambda so we definitely want to use them
+    $isALibraryWeCompiled = str_starts_with($lib, '/opt/lib');
     $doesNotExistInLambda = !in_array(basename($lib), $librariesThatExistOnLambda, true);
     $keep = $isALibraryWeCompiled || $doesNotExistInLambda;
     if (! $keep) {

--- a/utils/lib-copy/copy-dependencies.php
+++ b/utils/lib-copy/copy-dependencies.php
@@ -22,16 +22,6 @@ if (! ($argv[2] ?? false)) {
 }
 [$_, $pathToCheck, $targetDirectory] = $argv;
 
-// All the paths where shared libraries can be found
-const LIB_PATHS = [
-    // System libraries
-    '/lib64',
-    '/usr/lib64',
-    // Libraries we compiled from source are installed here
-    '/tmp/bref/lib',
-    '/tmp/bref/lib64',
-];
-
 $arch = 'x86';
 if (php_uname('m') !== 'x86_64') {
     $arch = 'arm';
@@ -44,10 +34,12 @@ $librariesThatExistOnLambda = array_filter($librariesThatExistOnLambda, function
     return ! str_contains($library, 'libgcrypt.so') && ! str_contains($library, 'libgpg-error.so');
 });
 
-$requiredLibraries = listAllDependenciesRecursively($pathToCheck);
+$requiredLibraries = listDependencies($pathToCheck);
 // Exclude existing system libraries
 $requiredLibraries = array_filter($requiredLibraries, function (string $lib) use ($librariesThatExistOnLambda) {
-    $keep = ! in_array(basename($lib), $librariesThatExistOnLambda, true);
+    $isALibraryWeCompiled = str_starts_with($lib, '/tmp/bref/lib');
+    $doesNotExistInLambda = !in_array(basename($lib), $librariesThatExistOnLambda, true);
+    $keep = $isALibraryWeCompiled || $doesNotExistInLambda;
     if (! $keep) {
         echo "Skipping $lib because it's already in Lambda" . PHP_EOL;
     }
@@ -58,46 +50,33 @@ $requiredLibraries = array_filter($requiredLibraries, function (string $lib) use
 foreach ($requiredLibraries as $libraryPath) {
     $targetPath = $targetDirectory . '/' . basename($libraryPath);
     echo "Copying $libraryPath to $targetPath" . PHP_EOL;
-    copy($libraryPath, $targetPath);
+    $success = copy($libraryPath, $targetPath);
+    if (! $success) {
+        throw new RuntimeException("Could not copy $libraryPath to $targetPath");
+    }
 }
 
 
 function listDependencies(string $path): array
 {
-    static $cache = [];
-    if (!isset($cache[$path])) {
-        echo $path . PHP_EOL;
-        $asString = shell_exec("objdump -p '$path' | grep NEEDED | awk '{ print $2 }'");
-        if (!$asString) {
-            $dependencies = [];
-        } else {
-            $dependencies = array_filter(explode(PHP_EOL, $asString));
+    // ldd lists the dependencies of a binary or library/extension (.so file)
+    exec("ldd $path 2>&1", $lines);
+    if (str_contains(end($lines), 'exited with unknown exit code (139)')) {
+        // We can't use `ldd` on binaries (like /opt/bin/php) because it fails on cross-platform builds
+        // so we fall back to `LD_TRACE_LOADED_OBJECTS` (which doesn't work for .so files, that's why we also try `ldd`)
+        // See https://stackoverflow.com/a/35905007/245552
+        $output = shell_exec("LD_TRACE_LOADED_OBJECTS=1 $path 2>&1");
+        if (!$output) {
+            throw new RuntimeException("Could not list dependencies for $path");
         }
-        $cache[$path] = array_map(fn(string $dependency) => findFullPath($dependency), $dependencies);
+        $lines = explode(PHP_EOL, $output);
     }
-    return $cache[$path];
-}
-
-function findFullPath(string $lib): string {
-    static $cache = [];
-    if (isset($cache[$lib])) {
-        return $cache[$lib];
-    }
-    foreach (LIB_PATHS as $libPath) {
-        if (file_exists("$libPath/$lib")) {
-            $cache[$lib] = "$libPath/$lib";
-            return "$libPath/$lib";
+    $dependencies = [];
+    foreach ($lines as $line) {
+        $matches = [];
+        if (preg_match('/=> (.*) \(0x[0-9a-f]+\)/', $line, $matches)) {
+            $dependencies[] = $matches[1];
         }
     }
-    throw new RuntimeException("Dependency '$lib' not found");
-}
-
-function listAllDependenciesRecursively(string $path): array
-{
-    $dependencies = listDependencies($path);
-    $allDependencies = [];
-    foreach ($dependencies as $dependency) {
-        $allDependencies = array_merge($allDependencies, listAllDependenciesRecursively($dependency));
-    }
-    return array_unique(array_merge($dependencies, $allDependencies));
+    return $dependencies;
 }


### PR DESCRIPTION
I noticed some differences in libs packaged inside layers for Bref v2.

Here's a comparison with v1: https://gist.github.com/mnapoli/99a46134a7d93e440480888ae29e94ff

I noticed that some libs we compile are not shipped in the layers, and I think I tracked that bug to the utility that copies system libraries. I am adding some tests and will fix that in that PR.