### PR TITLE
Use OpenSSL 3.0 LTS on PHP 8.1 and 8.2

### DIFF
--- a/php-80/Dockerfile
+++ b/php-80/Dockerfile
@@ -83,11 +83,11 @@ ENV CA_BUNDLE_SOURCE="https://curl.se/ca/cacert.pem"
 ENV CA_BUNDLE="${INSTALL_DIR}/bref/ssl/cert.pem"
 RUN set -xe; \
     mkdir -p ${OPENSSL_BUILD_DIR}; \
-    curl -Ls  https://github.com/openssl/openssl/archive/OpenSSL_${VERSION_OPENSSL//./_}.tar.gz \
+    curl -Ls https://github.com/openssl/openssl/archive/OpenSSL_${VERSION_OPENSSL//./_}.tar.gz \
   | tar xzC ${OPENSSL_BUILD_DIR} --strip-components=1
 WORKDIR  ${OPENSSL_BUILD_DIR}/
 RUN CFLAGS="" \
-    CPPFLAGS="-I${INSTALL_DIR}/include  -I/usr/include" \
+    CPPFLAGS="-I${INSTALL_DIR}/include -I/usr/include" \
     LDFLAGS="-L${INSTALL_DIR}/lib64 -L${INSTALL_DIR}/lib" \
     ./config \
         --prefix=${INSTALL_DIR} \
@@ -121,7 +121,7 @@ RUN set -xe; \
   | tar xzC ${LIBSSH2_BUILD_DIR} --strip-components=1
 WORKDIR  ${LIBSSH2_BUILD_DIR}/bin/
 RUN CFLAGS="" \
-    CPPFLAGS="-I${INSTALL_DIR}/include  -I/usr/include" \
+    CPPFLAGS="-I${INSTALL_DIR}/include -I/usr/include" \
     LDFLAGS="-L${INSTALL_DIR}/lib64 -L${INSTALL_DIR}/lib" \
     cmake .. \
         # Build as a shared library (.so) instead of a static one
@@ -153,7 +153,7 @@ RUN set -xe; \
     | tar xzC ${NGHTTP2_BUILD_DIR} --strip-components=1
 WORKDIR  ${NGHTTP2_BUILD_DIR}/
 RUN CFLAGS="" \
-    CPPFLAGS="-I${INSTALL_DIR}/include  -I/usr/include" \
+    CPPFLAGS="-I${INSTALL_DIR}/include -I/usr/include" \
     LDFLAGS="-L${INSTALL_DIR}/lib64 -L${INSTALL_DIR}/lib" \
     ./configure \
     --enable-lib-only \
@@ -179,7 +179,7 @@ RUN set -xe; \
 WORKDIR  ${CURL_BUILD_DIR}/
 RUN ./buildconf \
  && CFLAGS="" \
-    CPPFLAGS="-I${INSTALL_DIR}/include  -I/usr/include" \
+    CPPFLAGS="-I${INSTALL_DIR}/include -I/usr/include" \
     LDFLAGS="-L${INSTALL_DIR}/lib64 -L${INSTALL_DIR}/lib" \
     ./configure \
     --prefix=${INSTALL_DIR} \
@@ -220,7 +220,7 @@ RUN set -xe; \
   | tar xJC ${XML2_BUILD_DIR} --strip-components=1
 WORKDIR  ${XML2_BUILD_DIR}/
 RUN CFLAGS="" \
-    CPPFLAGS="-I${INSTALL_DIR}/include  -I/usr/include" \
+    CPPFLAGS="-I${INSTALL_DIR}/include -I/usr/include" \
     LDFLAGS="-L${INSTALL_DIR}/lib64 -L${INSTALL_DIR}/lib" \
     ./configure \
     --prefix=${INSTALL_DIR} \
@@ -250,7 +250,7 @@ RUN set -xe; \
   | tar xzC ${ZIP_BUILD_DIR} --strip-components=1
 WORKDIR  ${ZIP_BUILD_DIR}/bin/
 RUN CFLAGS="" \
-    CPPFLAGS="-I${INSTALL_DIR}/include  -I/usr/include" \
+    CPPFLAGS="-I${INSTALL_DIR}/include -I/usr/include" \
     LDFLAGS="-L${INSTALL_DIR}/lib64 -L${INSTALL_DIR}/lib" \
     cmake .. \
         -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} \
@@ -271,7 +271,7 @@ RUN set -xe; \
   | tar xzC ${LIBSODIUM_BUILD_DIR} --strip-components=1
 WORKDIR  ${LIBSODIUM_BUILD_DIR}/
 RUN CFLAGS="" \
-    CPPFLAGS="-I${INSTALL_DIR}/include  -I/usr/include" \
+    CPPFLAGS="-I${INSTALL_DIR}/include -I/usr/include" \
     LDFLAGS="-L${INSTALL_DIR}/lib64 -L${INSTALL_DIR}/lib" \
     ./autogen.sh \
 && ./configure --prefix=${INSTALL_DIR}
@@ -293,7 +293,7 @@ RUN set -xe; \
     | tar xzC ${POSTGRES_BUILD_DIR} --strip-components=1
 WORKDIR  ${POSTGRES_BUILD_DIR}/
 RUN CFLAGS="" \
-    CPPFLAGS="-I${INSTALL_DIR}/include  -I/usr/include" \
+    CPPFLAGS="-I${INSTALL_DIR}/include -I/usr/include" \
     LDFLAGS="-L${INSTALL_DIR}/lib64 -L${INSTALL_DIR}/lib" \
     ./configure --prefix=${INSTALL_DIR} --with-openssl --without-readline
 RUN cd ${POSTGRES_BUILD_DIR}/src/interfaces/libpq && make && make install

--- a/php-81/Dockerfile
+++ b/php-81/Dockerfile
@@ -77,13 +77,13 @@ RUN mkdir -p ${BUILD_DIR}  \
 # Needed by:
 #   - curl
 #   - php
-ENV VERSION_OPENSSL=1.1.1t
+ENV VERSION_OPENSSL=3.0.8
 ENV OPENSSL_BUILD_DIR=${BUILD_DIR}/openssl
 ENV CA_BUNDLE_SOURCE="https://curl.se/ca/cacert.pem"
 ENV CA_BUNDLE="${INSTALL_DIR}/bref/ssl/cert.pem"
 RUN set -xe; \
     mkdir -p ${OPENSSL_BUILD_DIR}; \
-    curl -Ls  https://github.com/openssl/openssl/archive/OpenSSL_${VERSION_OPENSSL//./_}.tar.gz \
+    curl -Ls https://github.com/openssl/openssl/releases/download/openssl-${VERSION_OPENSSL}/openssl-${VERSION_OPENSSL}.tar.gz \
   | tar xzC ${OPENSSL_BUILD_DIR} --strip-components=1
 WORKDIR  ${OPENSSL_BUILD_DIR}/
 RUN CFLAGS="" \

--- a/php-81/Dockerfile
+++ b/php-81/Dockerfile
@@ -77,6 +77,7 @@ RUN mkdir -p ${BUILD_DIR}  \
 # Needed by:
 #   - curl
 #   - php
+RUN yum install -y perl-IPC-Cmd
 ENV VERSION_OPENSSL=3.0.8
 ENV OPENSSL_BUILD_DIR=${BUILD_DIR}/openssl
 ENV CA_BUNDLE_SOURCE="https://curl.se/ca/cacert.pem"
@@ -87,7 +88,7 @@ RUN set -xe; \
   | tar xzC ${OPENSSL_BUILD_DIR} --strip-components=1
 WORKDIR  ${OPENSSL_BUILD_DIR}/
 RUN CFLAGS="" \
-    CPPFLAGS="-I${INSTALL_DIR}/include  -I/usr/include" \
+    CPPFLAGS="-I${INSTALL_DIR}/include -I/usr/include" \
     LDFLAGS="-L${INSTALL_DIR}/lib64 -L${INSTALL_DIR}/lib" \
     ./config \
         --prefix=${INSTALL_DIR} \
@@ -121,7 +122,7 @@ RUN set -xe; \
   | tar xzC ${LIBSSH2_BUILD_DIR} --strip-components=1
 WORKDIR  ${LIBSSH2_BUILD_DIR}/bin/
 RUN CFLAGS="" \
-    CPPFLAGS="-I${INSTALL_DIR}/include  -I/usr/include" \
+    CPPFLAGS="-I${INSTALL_DIR}/include -I/usr/include" \
     LDFLAGS="-L${INSTALL_DIR}/lib64 -L${INSTALL_DIR}/lib" \
     cmake .. \
         # Build as a shared library (.so) instead of a static one
@@ -153,7 +154,7 @@ RUN set -xe; \
     | tar xzC ${NGHTTP2_BUILD_DIR} --strip-components=1
 WORKDIR  ${NGHTTP2_BUILD_DIR}/
 RUN CFLAGS="" \
-    CPPFLAGS="-I${INSTALL_DIR}/include  -I/usr/include" \
+    CPPFLAGS="-I${INSTALL_DIR}/include -I/usr/include" \
     LDFLAGS="-L${INSTALL_DIR}/lib64 -L${INSTALL_DIR}/lib" \
     ./configure \
     --enable-lib-only \
@@ -179,7 +180,7 @@ RUN set -xe; \
 WORKDIR  ${CURL_BUILD_DIR}/
 RUN ./buildconf \
  && CFLAGS="" \
-    CPPFLAGS="-I${INSTALL_DIR}/include  -I/usr/include" \
+    CPPFLAGS="-I${INSTALL_DIR}/include -I/usr/include" \
     LDFLAGS="-L${INSTALL_DIR}/lib64 -L${INSTALL_DIR}/lib" \
     ./configure \
     --prefix=${INSTALL_DIR} \
@@ -220,7 +221,7 @@ RUN set -xe; \
   | tar xJC ${XML2_BUILD_DIR} --strip-components=1
 WORKDIR  ${XML2_BUILD_DIR}/
 RUN CFLAGS="" \
-    CPPFLAGS="-I${INSTALL_DIR}/include  -I/usr/include" \
+    CPPFLAGS="-I${INSTALL_DIR}/include -I/usr/include" \
     LDFLAGS="-L${INSTALL_DIR}/lib64 -L${INSTALL_DIR}/lib" \
     ./configure \
     --prefix=${INSTALL_DIR} \
@@ -250,7 +251,7 @@ RUN set -xe; \
   | tar xzC ${ZIP_BUILD_DIR} --strip-components=1
 WORKDIR  ${ZIP_BUILD_DIR}/bin/
 RUN CFLAGS="" \
-    CPPFLAGS="-I${INSTALL_DIR}/include  -I/usr/include" \
+    CPPFLAGS="-I${INSTALL_DIR}/include -I/usr/include" \
     LDFLAGS="-L${INSTALL_DIR}/lib64 -L${INSTALL_DIR}/lib" \
     cmake .. \
         -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} \
@@ -271,7 +272,7 @@ RUN set -xe; \
   | tar xzC ${LIBSODIUM_BUILD_DIR} --strip-components=1
 WORKDIR  ${LIBSODIUM_BUILD_DIR}/
 RUN CFLAGS="" \
-    CPPFLAGS="-I${INSTALL_DIR}/include  -I/usr/include" \
+    CPPFLAGS="-I${INSTALL_DIR}/include -I/usr/include" \
     LDFLAGS="-L${INSTALL_DIR}/lib64 -L${INSTALL_DIR}/lib" \
     ./autogen.sh \
 && ./configure --prefix=${INSTALL_DIR}
@@ -293,7 +294,7 @@ RUN set -xe; \
     | tar xzC ${POSTGRES_BUILD_DIR} --strip-components=1
 WORKDIR  ${POSTGRES_BUILD_DIR}/
 RUN CFLAGS="" \
-    CPPFLAGS="-I${INSTALL_DIR}/include  -I/usr/include" \
+    CPPFLAGS="-I${INSTALL_DIR}/include -I/usr/include" \
     LDFLAGS="-L${INSTALL_DIR}/lib64 -L${INSTALL_DIR}/lib" \
     ./configure --prefix=${INSTALL_DIR} --with-openssl --without-readline
 RUN cd ${POSTGRES_BUILD_DIR}/src/interfaces/libpq && make && make install

--- a/php-82/Dockerfile
+++ b/php-82/Dockerfile
@@ -77,13 +77,13 @@ RUN mkdir -p ${BUILD_DIR}  \
 # Needed by:
 #   - curl
 #   - php
-ENV VERSION_OPENSSL=1.1.1t
+ENV VERSION_OPENSSL=3.0.8
 ENV OPENSSL_BUILD_DIR=${BUILD_DIR}/openssl
 ENV CA_BUNDLE_SOURCE="https://curl.se/ca/cacert.pem"
 ENV CA_BUNDLE="${INSTALL_DIR}/bref/ssl/cert.pem"
 RUN set -xe; \
     mkdir -p ${OPENSSL_BUILD_DIR}; \
-    curl -Ls  https://github.com/openssl/openssl/archive/OpenSSL_${VERSION_OPENSSL//./_}.tar.gz \
+    curl -Ls https://github.com/openssl/openssl/releases/download/openssl-${VERSION_OPENSSL}/openssl-${VERSION_OPENSSL}.tar.gz \
   | tar xzC ${OPENSSL_BUILD_DIR} --strip-components=1
 WORKDIR  ${OPENSSL_BUILD_DIR}/
 RUN CFLAGS="" \

--- a/php-82/Dockerfile
+++ b/php-82/Dockerfile
@@ -77,6 +77,7 @@ RUN mkdir -p ${BUILD_DIR}  \
 # Needed by:
 #   - curl
 #   - php
+RUN yum install -y perl-IPC-Cmd
 ENV VERSION_OPENSSL=3.0.8
 ENV OPENSSL_BUILD_DIR=${BUILD_DIR}/openssl
 ENV CA_BUNDLE_SOURCE="https://curl.se/ca/cacert.pem"
@@ -87,7 +88,7 @@ RUN set -xe; \
   | tar xzC ${OPENSSL_BUILD_DIR} --strip-components=1
 WORKDIR  ${OPENSSL_BUILD_DIR}/
 RUN CFLAGS="" \
-    CPPFLAGS="-I${INSTALL_DIR}/include  -I/usr/include" \
+    CPPFLAGS="-I${INSTALL_DIR}/include -I/usr/include" \
     LDFLAGS="-L${INSTALL_DIR}/lib64 -L${INSTALL_DIR}/lib" \
     ./config \
         --prefix=${INSTALL_DIR} \
@@ -121,7 +122,7 @@ RUN set -xe; \
   | tar xzC ${LIBSSH2_BUILD_DIR} --strip-components=1
 WORKDIR  ${LIBSSH2_BUILD_DIR}/bin/
 RUN CFLAGS="" \
-    CPPFLAGS="-I${INSTALL_DIR}/include  -I/usr/include" \
+    CPPFLAGS="-I${INSTALL_DIR}/include -I/usr/include" \
     LDFLAGS="-L${INSTALL_DIR}/lib64 -L${INSTALL_DIR}/lib" \
     cmake .. \
         # Build as a shared library (.so) instead of a static one
@@ -153,7 +154,7 @@ RUN set -xe; \
     | tar xzC ${NGHTTP2_BUILD_DIR} --strip-components=1
 WORKDIR  ${NGHTTP2_BUILD_DIR}/
 RUN CFLAGS="" \
-    CPPFLAGS="-I${INSTALL_DIR}/include  -I/usr/include" \
+    CPPFLAGS="-I${INSTALL_DIR}/include -I/usr/include" \
     LDFLAGS="-L${INSTALL_DIR}/lib64 -L${INSTALL_DIR}/lib" \
     ./configure \
     --enable-lib-only \
@@ -179,7 +180,7 @@ RUN set -xe; \
 WORKDIR  ${CURL_BUILD_DIR}/
 RUN ./buildconf \
  && CFLAGS="" \
-    CPPFLAGS="-I${INSTALL_DIR}/include  -I/usr/include" \
+    CPPFLAGS="-I${INSTALL_DIR}/include -I/usr/include" \
     LDFLAGS="-L${INSTALL_DIR}/lib64 -L${INSTALL_DIR}/lib" \
     ./configure \
     --prefix=${INSTALL_DIR} \
@@ -220,7 +221,7 @@ RUN set -xe; \
   | tar xJC ${XML2_BUILD_DIR} --strip-components=1
 WORKDIR  ${XML2_BUILD_DIR}/
 RUN CFLAGS="" \
-    CPPFLAGS="-I${INSTALL_DIR}/include  -I/usr/include" \
+    CPPFLAGS="-I${INSTALL_DIR}/include -I/usr/include" \
     LDFLAGS="-L${INSTALL_DIR}/lib64 -L${INSTALL_DIR}/lib" \
     ./configure \
     --prefix=${INSTALL_DIR} \
@@ -250,7 +251,7 @@ RUN set -xe; \
   | tar xzC ${ZIP_BUILD_DIR} --strip-components=1
 WORKDIR  ${ZIP_BUILD_DIR}/bin/
 RUN CFLAGS="" \
-    CPPFLAGS="-I${INSTALL_DIR}/include  -I/usr/include" \
+    CPPFLAGS="-I${INSTALL_DIR}/include -I/usr/include" \
     LDFLAGS="-L${INSTALL_DIR}/lib64 -L${INSTALL_DIR}/lib" \
     cmake .. \
         -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} \
@@ -271,7 +272,7 @@ RUN set -xe; \
   | tar xzC ${LIBSODIUM_BUILD_DIR} --strip-components=1
 WORKDIR  ${LIBSODIUM_BUILD_DIR}/
 RUN CFLAGS="" \
-    CPPFLAGS="-I${INSTALL_DIR}/include  -I/usr/include" \
+    CPPFLAGS="-I${INSTALL_DIR}/include -I/usr/include" \
     LDFLAGS="-L${INSTALL_DIR}/lib64 -L${INSTALL_DIR}/lib" \
     ./autogen.sh \
 && ./configure --prefix=${INSTALL_DIR}
@@ -293,7 +294,7 @@ RUN set -xe; \
     | tar xzC ${POSTGRES_BUILD_DIR} --strip-components=1
 WORKDIR  ${POSTGRES_BUILD_DIR}/
 RUN CFLAGS="" \
-    CPPFLAGS="-I${INSTALL_DIR}/include  -I/usr/include" \
+    CPPFLAGS="-I${INSTALL_DIR}/include -I/usr/include" \
     LDFLAGS="-L${INSTALL_DIR}/lib64 -L${INSTALL_DIR}/lib" \
     ./configure --prefix=${INSTALL_DIR} --with-openssl --without-readline
 RUN cd ${POSTGRES_BUILD_DIR}/src/interfaces/libpq && make && make install

--- a/tests/test_2_extensions.php
+++ b/tests/test_2_extensions.php
@@ -81,7 +81,7 @@ $extensions = [
     // https://github.com/brefphp/aws-lambda-layers/issues/42
     'curl-http2' => defined('CURL_HTTP_VERSION_2'),
     // Make sure we are not using the default AL2 OpenSSL version (7.79)
-    'curl-openssl' => str_starts_with(curl_version()['ssl_version'], 'OpenSSL/3.0'),
+    'curl-openssl' => str_starts_with(curl_version()['ssl_version'], 'OpenSSL/1.1.1') || str_starts_with(curl_version()['ssl_version'], 'OpenSSL/3.0'),
     // Check that the default certificate file exists
     // https://github.com/brefphp/aws-lambda-layers/issues/53
     'curl-openssl-certificates' => file_exists(openssl_get_cert_locations()['default_cert_file']),

--- a/tests/test_2_extensions.php
+++ b/tests/test_2_extensions.php
@@ -81,7 +81,7 @@ $extensions = [
     // https://github.com/brefphp/aws-lambda-layers/issues/42
     'curl-http2' => defined('CURL_HTTP_VERSION_2'),
     // Make sure we are not using the default AL2 OpenSSL version (7.79)
-    'curl-openssl' => str_starts_with(curl_version()['ssl_version'], 'OpenSSL/1.1.1'),
+    'curl-openssl' => str_starts_with(curl_version()['ssl_version'], 'OpenSSL/3.0'),
     // Check that the default certificate file exists
     // https://github.com/brefphp/aws-lambda-layers/issues/53
     'curl-openssl-certificates' => file_exists(openssl_get_cert_locations()['default_cert_file']),


### PR DESCRIPTION
Closes https://github.com/brefphp/aws-lambda-layers/issues/73. Note that we are using 3.0.x LTS, not 3.x (3.1.x is not LTS, and it's not clear if PHP actually supports it).