### PR TITLE
Enable TLS 1.3 and upgrade to cURL 8.1.0

### DIFF
--- a/php-80/Dockerfile
+++ b/php-80/Dockerfile
@@ -106,6 +106,39 @@ RUN mkdir -p ${INSTALL_DIR}/bref/ssl && curl -Lk -o ${CA_BUNDLE} ${CA_BUNDLE_SOU
 
 
 ###############################################################################
+# LIBXML2
+# https://github.com/GNOME/libxml2/releases
+# Uses:
+#   - zlib
+# Needed by:
+#   - php
+#   - libnghttp2
+ENV VERSION_XML2=2.11.2
+ENV XML2_BUILD_DIR=${BUILD_DIR}/xml2
+RUN set -xe; \
+    mkdir -p ${XML2_BUILD_DIR}; \
+    curl -Ls https://download.gnome.org/sources/libxml2/${VERSION_XML2%.*}/libxml2-${VERSION_XML2}.tar.xz \
+  | tar xJC ${XML2_BUILD_DIR} --strip-components=1
+WORKDIR  ${XML2_BUILD_DIR}/
+RUN CFLAGS="" \
+    CPPFLAGS="-I${INSTALL_DIR}/include -I/usr/include" \
+    LDFLAGS="-L${INSTALL_DIR}/lib64 -L${INSTALL_DIR}/lib" \
+    ./configure \
+    --prefix=${INSTALL_DIR} \
+    --with-sysroot=${INSTALL_DIR} \
+    --enable-shared \
+    --disable-static \
+    --with-html \
+    --with-history \
+    --enable-ipv6=no \
+    --with-icu \
+    --with-zlib \
+    --without-python
+RUN make install \
+ && cp xml2-config ${INSTALL_DIR}/bin/xml2-config
+
+
+###############################################################################
 # LIBSSH2
 # https://github.com/libssh2/libssh2/releases
 # Needs:
@@ -143,6 +176,7 @@ RUN cmake  --build . --target install
 # Needs:
 #   - zlib
 #   - OpenSSL
+#   - libxml2
 # Needed by:
 #   - curl
 ENV VERSION_NGHTTP2=1.53.0
@@ -168,6 +202,7 @@ RUN make install
 # #   - zlib
 # #   - OpenSSL
 # #   - libssh2
+# #   - libnghttp2
 # # Needed by:
 # #   - php
 ENV VERSION_CURL=7.85.0
@@ -203,38 +238,6 @@ RUN ./buildconf \
     --with-libssh2 \
     --with-nghttp2
 RUN make install
-
-
-###############################################################################
-# LIBXML2
-# https://github.com/GNOME/libxml2/releases
-# Uses:
-#   - zlib
-# Needed by:
-#   - php
-ENV VERSION_XML2=2.11.2
-ENV XML2_BUILD_DIR=${BUILD_DIR}/xml2
-RUN set -xe; \
-    mkdir -p ${XML2_BUILD_DIR}; \
-    curl -Ls https://download.gnome.org/sources/libxml2/${VERSION_XML2%.*}/libxml2-${VERSION_XML2}.tar.xz \
-  | tar xJC ${XML2_BUILD_DIR} --strip-components=1
-WORKDIR  ${XML2_BUILD_DIR}/
-RUN CFLAGS="" \
-    CPPFLAGS="-I${INSTALL_DIR}/include -I/usr/include" \
-    LDFLAGS="-L${INSTALL_DIR}/lib64 -L${INSTALL_DIR}/lib" \
-    ./configure \
-    --prefix=${INSTALL_DIR} \
-    --with-sysroot=${INSTALL_DIR} \
-    --enable-shared \
-    --disable-static \
-    --with-html \
-    --with-history \
-    --enable-ipv6=no \
-    --with-icu \
-    --with-zlib \
-    --without-python
-RUN make install \
- && cp xml2-config ${INSTALL_DIR}/bin/xml2-config
 
 
 ###############################################################################

--- a/php-81/Dockerfile
+++ b/php-81/Dockerfile
@@ -107,6 +107,39 @@ RUN mkdir -p ${INSTALL_DIR}/bref/ssl && curl -Lk -o ${CA_BUNDLE} ${CA_BUNDLE_SOU
 
 
 ###############################################################################
+# LIBXML2
+# https://github.com/GNOME/libxml2/releases
+# Uses:
+#   - zlib
+# Needed by:
+#   - php
+#   - libnghttp2
+ENV VERSION_XML2=2.11.2
+ENV XML2_BUILD_DIR=${BUILD_DIR}/xml2
+RUN set -xe; \
+    mkdir -p ${XML2_BUILD_DIR}; \
+    curl -Ls https://download.gnome.org/sources/libxml2/${VERSION_XML2%.*}/libxml2-${VERSION_XML2}.tar.xz \
+  | tar xJC ${XML2_BUILD_DIR} --strip-components=1
+WORKDIR  ${XML2_BUILD_DIR}/
+RUN CFLAGS="" \
+    CPPFLAGS="-I${INSTALL_DIR}/include -I/usr/include" \
+    LDFLAGS="-L${INSTALL_DIR}/lib64 -L${INSTALL_DIR}/lib" \
+    ./configure \
+    --prefix=${INSTALL_DIR} \
+    --with-sysroot=${INSTALL_DIR} \
+    --enable-shared \
+    --disable-static \
+    --with-html \
+    --with-history \
+    --enable-ipv6=no \
+    --with-icu \
+    --with-zlib \
+    --without-python
+RUN make install \
+ && cp xml2-config ${INSTALL_DIR}/bin/xml2-config
+
+
+###############################################################################
 # LIBSSH2
 # https://github.com/libssh2/libssh2/releases
 # Needs:
@@ -144,6 +177,7 @@ RUN cmake  --build . --target install
 # Needs:
 #   - zlib
 #   - OpenSSL
+#   - libxml2
 # Needed by:
 #   - curl
 ENV VERSION_NGHTTP2=1.53.0
@@ -169,6 +203,7 @@ RUN make install
 # #   - zlib
 # #   - OpenSSL
 # #   - libssh2
+# #   - libnghttp2
 # # Needed by:
 # #   - php
 ENV VERSION_CURL=7.85.0
@@ -204,38 +239,6 @@ RUN ./buildconf \
     --with-libssh2 \
     --with-nghttp2
 RUN make install
-
-
-###############################################################################
-# LIBXML2
-# https://github.com/GNOME/libxml2/releases
-# Uses:
-#   - zlib
-# Needed by:
-#   - php
-ENV VERSION_XML2=2.11.2
-ENV XML2_BUILD_DIR=${BUILD_DIR}/xml2
-RUN set -xe; \
-    mkdir -p ${XML2_BUILD_DIR}; \
-    curl -Ls https://download.gnome.org/sources/libxml2/${VERSION_XML2%.*}/libxml2-${VERSION_XML2}.tar.xz \
-  | tar xJC ${XML2_BUILD_DIR} --strip-components=1
-WORKDIR  ${XML2_BUILD_DIR}/
-RUN CFLAGS="" \
-    CPPFLAGS="-I${INSTALL_DIR}/include -I/usr/include" \
-    LDFLAGS="-L${INSTALL_DIR}/lib64 -L${INSTALL_DIR}/lib" \
-    ./configure \
-    --prefix=${INSTALL_DIR} \
-    --with-sysroot=${INSTALL_DIR} \
-    --enable-shared \
-    --disable-static \
-    --with-html \
-    --with-history \
-    --enable-ipv6=no \
-    --with-icu \
-    --with-zlib \
-    --without-python
-RUN make install \
- && cp xml2-config ${INSTALL_DIR}/bin/xml2-config
 
 
 ###############################################################################

--- a/php-81/Dockerfile
+++ b/php-81/Dockerfile
@@ -94,6 +94,7 @@ RUN CFLAGS="" \
         --prefix=${INSTALL_DIR} \
         --openssldir=${INSTALL_DIR}/bref/ssl \
         --release \
+        enable-tls1_3 \
         no-tests \
         shared \
         zlib
@@ -206,7 +207,7 @@ RUN make install
 # #   - libnghttp2
 # # Needed by:
 # #   - php
-ENV VERSION_CURL=7.85.0
+ENV VERSION_CURL=8.1.0
 ENV CURL_BUILD_DIR=${BUILD_DIR}/curl
 RUN set -xe; \
     mkdir -p ${CURL_BUILD_DIR}/bin; \

--- a/php-82/Dockerfile
+++ b/php-82/Dockerfile
@@ -107,6 +107,39 @@ RUN mkdir -p ${INSTALL_DIR}/bref/ssl && curl -Lk -o ${CA_BUNDLE} ${CA_BUNDLE_SOU
 
 
 ###############################################################################
+# LIBXML2
+# https://github.com/GNOME/libxml2/releases
+# Uses:
+#   - zlib
+# Needed by:
+#   - php
+#   - libnghttp2
+ENV VERSION_XML2=2.11.2
+ENV XML2_BUILD_DIR=${BUILD_DIR}/xml2
+RUN set -xe; \
+    mkdir -p ${XML2_BUILD_DIR}; \
+    curl -Ls https://download.gnome.org/sources/libxml2/${VERSION_XML2%.*}/libxml2-${VERSION_XML2}.tar.xz \
+  | tar xJC ${XML2_BUILD_DIR} --strip-components=1
+WORKDIR  ${XML2_BUILD_DIR}/
+RUN CFLAGS="" \
+    CPPFLAGS="-I${INSTALL_DIR}/include -I/usr/include" \
+    LDFLAGS="-L${INSTALL_DIR}/lib64 -L${INSTALL_DIR}/lib" \
+    ./configure \
+    --prefix=${INSTALL_DIR} \
+    --with-sysroot=${INSTALL_DIR} \
+    --enable-shared \
+    --disable-static \
+    --with-html \
+    --with-history \
+    --enable-ipv6=no \
+    --with-icu \
+    --with-zlib \
+    --without-python
+RUN make install \
+ && cp xml2-config ${INSTALL_DIR}/bin/xml2-config
+
+
+###############################################################################
 # LIBSSH2
 # https://github.com/libssh2/libssh2/releases
 # Needs:
@@ -144,6 +177,7 @@ RUN cmake  --build . --target install
 # Needs:
 #   - zlib
 #   - OpenSSL
+#   - libxml2
 # Needed by:
 #   - curl
 ENV VERSION_NGHTTP2=1.53.0
@@ -169,6 +203,7 @@ RUN make install
 # #   - zlib
 # #   - OpenSSL
 # #   - libssh2
+# #   - libnghttp2
 # # Needed by:
 # #   - php
 ENV VERSION_CURL=7.85.0
@@ -204,38 +239,6 @@ RUN ./buildconf \
     --with-libssh2 \
     --with-nghttp2
 RUN make install
-
-
-###############################################################################
-# LIBXML2
-# https://github.com/GNOME/libxml2/releases
-# Uses:
-#   - zlib
-# Needed by:
-#   - php
-ENV VERSION_XML2=2.11.2
-ENV XML2_BUILD_DIR=${BUILD_DIR}/xml2
-RUN set -xe; \
-    mkdir -p ${XML2_BUILD_DIR}; \
-    curl -Ls https://download.gnome.org/sources/libxml2/${VERSION_XML2%.*}/libxml2-${VERSION_XML2}.tar.xz \
-  | tar xJC ${XML2_BUILD_DIR} --strip-components=1
-WORKDIR  ${XML2_BUILD_DIR}/
-RUN CFLAGS="" \
-    CPPFLAGS="-I${INSTALL_DIR}/include -I/usr/include" \
-    LDFLAGS="-L${INSTALL_DIR}/lib64 -L${INSTALL_DIR}/lib" \
-    ./configure \
-    --prefix=${INSTALL_DIR} \
-    --with-sysroot=${INSTALL_DIR} \
-    --enable-shared \
-    --disable-static \
-    --with-html \
-    --with-history \
-    --enable-ipv6=no \
-    --with-icu \
-    --with-zlib \
-    --without-python
-RUN make install \
- && cp xml2-config ${INSTALL_DIR}/bin/xml2-config
 
 
 ###############################################################################

--- a/php-82/Dockerfile
+++ b/php-82/Dockerfile
@@ -94,6 +94,7 @@ RUN CFLAGS="" \
         --prefix=${INSTALL_DIR} \
         --openssldir=${INSTALL_DIR}/bref/ssl \
         --release \
+        enable-tls1_3 \
         no-tests \
         shared \
         zlib
@@ -206,7 +207,7 @@ RUN make install
 # #   - libnghttp2
 # # Needed by:
 # #   - php
-ENV VERSION_CURL=7.85.0
+ENV VERSION_CURL=8.1.0
 ENV CURL_BUILD_DIR=${BUILD_DIR}/curl
 RUN set -xe; \
     mkdir -p ${CURL_BUILD_DIR}/bin; \


### PR DESCRIPTION
1. This upgrade applies only to PHP 8.1 and 8.2.
2. I've also fixed Fix NGHTTP2 warnings due to no libxml2 - I can move this to another PR if needed.