### PR TITLE
Upgrade to cURL 8.1.1 and backport changes to PHP 8.0 too

### DIFF
--- a/php-80/Dockerfile
+++ b/php-80/Dockerfile
@@ -93,6 +93,7 @@ RUN CFLAGS="" \
         --prefix=${INSTALL_DIR} \
         --openssldir=${INSTALL_DIR}/bref/ssl \
         --release \
+        enable-tls1_3 \
         no-tests \
         shared \
         zlib
@@ -205,7 +206,7 @@ RUN make install
 # #   - libnghttp2
 # # Needed by:
 # #   - php
-ENV VERSION_CURL=7.85.0
+ENV VERSION_CURL=8.1.1
 ENV CURL_BUILD_DIR=${BUILD_DIR}/curl
 RUN set -xe; \
     mkdir -p ${CURL_BUILD_DIR}/bin; \

--- a/php-81/Dockerfile
+++ b/php-81/Dockerfile
@@ -207,7 +207,7 @@ RUN make install
 # #   - libnghttp2
 # # Needed by:
 # #   - php
-ENV VERSION_CURL=8.1.0
+ENV VERSION_CURL=8.1.1
 ENV CURL_BUILD_DIR=${BUILD_DIR}/curl
 RUN set -xe; \
     mkdir -p ${CURL_BUILD_DIR}/bin; \

--- a/php-82/Dockerfile
+++ b/php-82/Dockerfile
@@ -207,7 +207,7 @@ RUN make install
 # #   - libnghttp2
 # # Needed by:
 # #   - php
-ENV VERSION_CURL=8.1.0
+ENV VERSION_CURL=8.1.1
 ENV CURL_BUILD_DIR=${BUILD_DIR}/curl
 RUN set -xe; \
     mkdir -p ${CURL_BUILD_DIR}/bin; \


### PR DESCRIPTION
The segfaults I was seeing previously were ultimately caused by the nghttp2 library not being linked correctly in Laravel Vapor, and so the cURL upgrade in bref is fine to do, even on OpenSSL 1.1.x for PHP 8.0. It's nice that we can finally get all the security and bug fixes to cURL into all bref runtimes.