### PR TITLE
Check if the RUNTIME_CLASS is already set

### DIFF
--- a/layers/console/bootstrap.sh
+++ b/layers/console/bootstrap.sh
@@ -8,19 +8,20 @@ if [ -z "${RUNTIME_CLASS}" ]; then
   export RUNTIME_CLASS="Bref\ConsoleRuntime\Main"
 fi
 
-while true; do
-  if [ -z "${EXPERIMENTAL_AWS_LAMBDA_EXEC_WRAPPER}" ]; then
-    # Default behavior
+while true
+do
+    if [ -z "${EXPERIMENTAL_AWS_LAMBDA_EXEC_WRAPPER}" ]; then
+        # Default behavior
 
-    # We redirect stderr to stdout so that everything
-    # written on the output ends up in Cloudwatch automatically
-    php "/opt/bref/bootstrap.php" 2>&1
-  else
-    # A wrapper script is configured
-    # See https://docs.aws.amazon.com/lambda/latest/dg/runtimes-modify.html#runtime-wrapper
-    # NOTE: EXPERIMENTAL FEATURE, DO NOT USE!!!
-    # Note: If you do use it, open an issue or GitHub discussion or Slack thread
-    # and let us know why it's useful to you, we might turn it into an official feature
-    "${EXPERIMENTAL_AWS_LAMBDA_EXEC_WRAPPER}" php "/opt/bref/bootstrap.php" 2>&1
-  fi
+        # We redirect stderr to stdout so that everything
+        # written on the output ends up in Cloudwatch automatically
+        php "/opt/bref/bootstrap.php" 2>&1
+    else
+        # A wrapper script is configured
+        # See https://docs.aws.amazon.com/lambda/latest/dg/runtimes-modify.html#runtime-wrapper
+        # NOTE: EXPERIMENTAL FEATURE, DO NOT USE!!!
+        # Note: If you do use it, open an issue or GitHub discussion or Slack thread
+        # and let us know why it's useful to you, we might turn it into an official feature
+        "${EXPERIMENTAL_AWS_LAMBDA_EXEC_WRAPPER}" php "/opt/bref/bootstrap.php" 2>&1
+    fi
 done

--- a/layers/console/bootstrap.sh
+++ b/layers/console/bootstrap.sh
@@ -3,22 +3,24 @@
 # Fail on error
 set -e
 
-export RUNTIME_CLASS="Bref\ConsoleRuntime\Main"
+# check if the RUNTIME_CLASS is already set
+if [ -z "${RUNTIME_CLASS}" ]; then
+  export RUNTIME_CLASS="Bref\ConsoleRuntime\Main"
+fi
 
-while true
-do
-    if [ -z "${EXPERIMENTAL_AWS_LAMBDA_EXEC_WRAPPER}" ]; then
-        # Default behavior
+while true; do
+  if [ -z "${EXPERIMENTAL_AWS_LAMBDA_EXEC_WRAPPER}" ]; then
+    # Default behavior
 
-        # We redirect stderr to stdout so that everything
-        # written on the output ends up in Cloudwatch automatically
-        php "/opt/bref/bootstrap.php" 2>&1
-    else
-        # A wrapper script is configured
-        # See https://docs.aws.amazon.com/lambda/latest/dg/runtimes-modify.html#runtime-wrapper
-        # NOTE: EXPERIMENTAL FEATURE, DO NOT USE!!!
-        # Note: If you do use it, open an issue or GitHub discussion or Slack thread
-        # and let us know why it's useful to you, we might turn it into an official feature
-        "${EXPERIMENTAL_AWS_LAMBDA_EXEC_WRAPPER}" php "/opt/bref/bootstrap.php" 2>&1
-    fi
+    # We redirect stderr to stdout so that everything
+    # written on the output ends up in Cloudwatch automatically
+    php "/opt/bref/bootstrap.php" 2>&1
+  else
+    # A wrapper script is configured
+    # See https://docs.aws.amazon.com/lambda/latest/dg/runtimes-modify.html#runtime-wrapper
+    # NOTE: EXPERIMENTAL FEATURE, DO NOT USE!!!
+    # Note: If you do use it, open an issue or GitHub discussion or Slack thread
+    # and let us know why it's useful to you, we might turn it into an official feature
+    "${EXPERIMENTAL_AWS_LAMBDA_EXEC_WRAPPER}" php "/opt/bref/bootstrap.php" 2>&1
+  fi
 done

--- a/layers/fpm/bootstrap.sh
+++ b/layers/fpm/bootstrap.sh
@@ -8,19 +8,20 @@ if [ -z "${RUNTIME_CLASS}" ]; then
   export RUNTIME_CLASS="Bref\FpmRuntime\Main"
 fi
 
-while true; do
-  if [ -z "${EXPERIMENTAL_AWS_LAMBDA_EXEC_WRAPPER}" ]; then
-    # Default behavior
+while true
+do
+    if [ -z "${EXPERIMENTAL_AWS_LAMBDA_EXEC_WRAPPER}" ]; then
+        # Default behavior
 
-    # We redirect stderr to stdout so that everything
-    # written on the output ends up in Cloudwatch automatically
-    php "/opt/bref/bootstrap.php" 2>&1
-  else
-    # A wrapper script is configured
-    # See https://docs.aws.amazon.com/lambda/latest/dg/runtimes-modify.html#runtime-wrapper
-    # NOTE: EXPERIMENTAL FEATURE, DO NOT USE!!!
-    # Note: If you do use it, open an issue or GitHub discussion or Slack thread
-    # and let us know why it's useful to you, we might turn it into an official feature
-    "${EXPERIMENTAL_AWS_LAMBDA_EXEC_WRAPPER}" php "/opt/bref/bootstrap.php" 2>&1
-  fi
+        # We redirect stderr to stdout so that everything
+        # written on the output ends up in Cloudwatch automatically
+        php "/opt/bref/bootstrap.php" 2>&1
+    else
+        # A wrapper script is configured
+        # See https://docs.aws.amazon.com/lambda/latest/dg/runtimes-modify.html#runtime-wrapper
+        # NOTE: EXPERIMENTAL FEATURE, DO NOT USE!!!
+        # Note: If you do use it, open an issue or GitHub discussion or Slack thread
+        # and let us know why it's useful to you, we might turn it into an official feature
+        "${EXPERIMENTAL_AWS_LAMBDA_EXEC_WRAPPER}" php "/opt/bref/bootstrap.php" 2>&1
+    fi
 done

--- a/layers/fpm/bootstrap.sh
+++ b/layers/fpm/bootstrap.sh
@@ -3,22 +3,24 @@
 # Fail on error
 set -e
 
-export RUNTIME_CLASS="Bref\FpmRuntime\Main"
+# check if the RUNTIME_CLASS is already set
+if [ -z "${RUNTIME_CLASS}" ]; then
+  export RUNTIME_CLASS="Bref\FpmRuntime\Main"
+fi
 
-while true
-do
-    if [ -z "${EXPERIMENTAL_AWS_LAMBDA_EXEC_WRAPPER}" ]; then
-        # Default behavior
+while true; do
+  if [ -z "${EXPERIMENTAL_AWS_LAMBDA_EXEC_WRAPPER}" ]; then
+    # Default behavior
 
-        # We redirect stderr to stdout so that everything
-        # written on the output ends up in Cloudwatch automatically
-        php "/opt/bref/bootstrap.php" 2>&1
-    else
-        # A wrapper script is configured
-        # See https://docs.aws.amazon.com/lambda/latest/dg/runtimes-modify.html#runtime-wrapper
-        # NOTE: EXPERIMENTAL FEATURE, DO NOT USE!!!
-        # Note: If you do use it, open an issue or GitHub discussion or Slack thread
-        # and let us know why it's useful to you, we might turn it into an official feature
-        "${EXPERIMENTAL_AWS_LAMBDA_EXEC_WRAPPER}" php "/opt/bref/bootstrap.php" 2>&1
-    fi
+    # We redirect stderr to stdout so that everything
+    # written on the output ends up in Cloudwatch automatically
+    php "/opt/bref/bootstrap.php" 2>&1
+  else
+    # A wrapper script is configured
+    # See https://docs.aws.amazon.com/lambda/latest/dg/runtimes-modify.html#runtime-wrapper
+    # NOTE: EXPERIMENTAL FEATURE, DO NOT USE!!!
+    # Note: If you do use it, open an issue or GitHub discussion or Slack thread
+    # and let us know why it's useful to you, we might turn it into an official feature
+    "${EXPERIMENTAL_AWS_LAMBDA_EXEC_WRAPPER}" php "/opt/bref/bootstrap.php" 2>&1
+  fi
 done

--- a/layers/function/bootstrap.sh
+++ b/layers/function/bootstrap.sh
@@ -3,22 +3,24 @@
 # Fail on error
 set -e
 
-export RUNTIME_CLASS="Bref\FunctionRuntime\Main"
+# check if the RUNTIME_CLASS is already set
+if [ -z "${RUNTIME_CLASS}" ]; then
+  export RUNTIME_CLASS="Bref\FunctionRuntime\Main"
+fi
 
-while true
-do
-    if [ -z "${EXPERIMENTAL_AWS_LAMBDA_EXEC_WRAPPER}" ]; then
-        # Default behavior
+while true; do
+  if [ -z "${EXPERIMENTAL_AWS_LAMBDA_EXEC_WRAPPER}" ]; then
+    # Default behavior
 
-        # We redirect stderr to stdout so that everything
-        # written on the output ends up in Cloudwatch automatically
-        php "/opt/bref/bootstrap.php" 2>&1
-    else
-        # A wrapper script is configured
-        # See https://docs.aws.amazon.com/lambda/latest/dg/runtimes-modify.html#runtime-wrapper
-        # NOTE: EXPERIMENTAL FEATURE, DO NOT USE!!!
-        # Note: If you do use it, open an issue or GitHub discussion or Slack thread
-        # and let us know why it's useful to you, we might turn it into an official feature
-        "${EXPERIMENTAL_AWS_LAMBDA_EXEC_WRAPPER}" php "/opt/bref/bootstrap.php" 2>&1
-    fi
+    # We redirect stderr to stdout so that everything
+    # written on the output ends up in Cloudwatch automatically
+    php "/opt/bref/bootstrap.php" 2>&1
+  else
+    # A wrapper script is configured
+    # See https://docs.aws.amazon.com/lambda/latest/dg/runtimes-modify.html#runtime-wrapper
+    # NOTE: EXPERIMENTAL FEATURE, DO NOT USE!!!
+    # Note: If you do use it, open an issue or GitHub discussion or Slack thread
+    # and let us know why it's useful to you, we might turn it into an official feature
+    "${EXPERIMENTAL_AWS_LAMBDA_EXEC_WRAPPER}" php "/opt/bref/bootstrap.php" 2>&1
+  fi
 done

--- a/layers/function/bootstrap.sh
+++ b/layers/function/bootstrap.sh
@@ -8,19 +8,20 @@ if [ -z "${RUNTIME_CLASS}" ]; then
   export RUNTIME_CLASS="Bref\FunctionRuntime\Main"
 fi
 
-while true; do
-  if [ -z "${EXPERIMENTAL_AWS_LAMBDA_EXEC_WRAPPER}" ]; then
-    # Default behavior
+while true
+do
+    if [ -z "${EXPERIMENTAL_AWS_LAMBDA_EXEC_WRAPPER}" ]; then
+        # Default behavior
 
-    # We redirect stderr to stdout so that everything
-    # written on the output ends up in Cloudwatch automatically
-    php "/opt/bref/bootstrap.php" 2>&1
-  else
-    # A wrapper script is configured
-    # See https://docs.aws.amazon.com/lambda/latest/dg/runtimes-modify.html#runtime-wrapper
-    # NOTE: EXPERIMENTAL FEATURE, DO NOT USE!!!
-    # Note: If you do use it, open an issue or GitHub discussion or Slack thread
-    # and let us know why it's useful to you, we might turn it into an official feature
-    "${EXPERIMENTAL_AWS_LAMBDA_EXEC_WRAPPER}" php "/opt/bref/bootstrap.php" 2>&1
-  fi
+        # We redirect stderr to stdout so that everything
+        # written on the output ends up in Cloudwatch automatically
+        php "/opt/bref/bootstrap.php" 2>&1
+    else
+        # A wrapper script is configured
+        # See https://docs.aws.amazon.com/lambda/latest/dg/runtimes-modify.html#runtime-wrapper
+        # NOTE: EXPERIMENTAL FEATURE, DO NOT USE!!!
+        # Note: If you do use it, open an issue or GitHub discussion or Slack thread
+        # and let us know why it's useful to you, we might turn it into an official feature
+        "${EXPERIMENTAL_AWS_LAMBDA_EXEC_WRAPPER}" php "/opt/bref/bootstrap.php" 2>&1
+    fi
 done


### PR DESCRIPTION
The `bootstrap.sh` is always exporting the `RUNTIME_CLASS` variable, this PR will only set the variable if it is not already defined in the environment.

This also updates the `while` style code... Happy to undo that if needed.