### PR TITLE
Increases log_limit to 256k

### DIFF
--- a/layers/fpm/php-fpm.conf
+++ b/layers/fpm/php-fpm.conf
@@ -7,7 +7,7 @@ pid = /tmp/.bref/php-fpm.pid
 ;log_level = 'warning'
 
 ; New PHP 7.3 option that includes the maximum length when writing to stderr
-log_limit = 8192
+log_limit = 256000
 
 [default]
 pm = static


### PR DESCRIPTION
Hello!

I'm needing bigger logs, so I added a layer increasing the log_limit in my app.
But, since Cloudwatch now allows logs up to 256kb (https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/cloudwatch_limits_cwl.html), is there a chance this can be applied to the base layer?

Thanks from a fan!