### PR TITLE
Use newer zlib than shipped in AL2

### DIFF
--- a/php-80/Dockerfile
+++ b/php-80/Dockerfile
@@ -70,6 +70,42 @@ RUN mkdir -p ${BUILD_DIR}  \
 
 
 ###############################################################################
+# ZLIB Build
+# https://github.com/madler/zlib/releases
+# Needed for:
+#   - openssl
+#   - curl
+#   - php
+# Used By:
+#   - xml2
+ENV VERSION_ZLIB=1.3
+ENV ZLIB_BUILD_DIR=${BUILD_DIR}/xml2
+
+RUN set -xe; \
+    mkdir -p ${ZLIB_BUILD_DIR}; \
+# Download and upack the source code
+    curl -Ls http://zlib.net/zlib-${VERSION_ZLIB}.tar.xz \
+  | tar xJC ${ZLIB_BUILD_DIR} --strip-components=1
+
+# Move into the unpackaged code directory
+WORKDIR ${ZLIB_BUILD_DIR}/
+
+# Configure the build
+RUN set -xe; \
+    make distclean \
+ && CFLAGS="" \
+    CPPFLAGS="-I${INSTALL_DIR}/include  -I/usr/include" \
+    LDFLAGS="-L${INSTALL_DIR}/lib64 -L${INSTALL_DIR}/lib" \
+    ./configure \
+    --prefix=${INSTALL_DIR} \
+    --64
+
+RUN set -xe; \
+    make install \
+ && rm ${INSTALL_DIR}/lib/libz.a
+
+
+###############################################################################
 # OPENSSL
 # https://github.com/openssl/openssl/releases
 # Needs:

--- a/php-81/Dockerfile
+++ b/php-81/Dockerfile
@@ -70,6 +70,42 @@ RUN mkdir -p ${BUILD_DIR}  \
 
 
 ###############################################################################
+# ZLIB Build
+# https://github.com/madler/zlib/releases
+# Needed for:
+#   - openssl
+#   - curl
+#   - php
+# Used By:
+#   - xml2
+ENV VERSION_ZLIB=1.3
+ENV ZLIB_BUILD_DIR=${BUILD_DIR}/xml2
+
+RUN set -xe; \
+    mkdir -p ${ZLIB_BUILD_DIR}; \
+# Download and upack the source code
+    curl -Ls http://zlib.net/zlib-${VERSION_ZLIB}.tar.xz \
+  | tar xJC ${ZLIB_BUILD_DIR} --strip-components=1
+
+# Move into the unpackaged code directory
+WORKDIR ${ZLIB_BUILD_DIR}/
+
+# Configure the build
+RUN set -xe; \
+    make distclean \
+ && CFLAGS="" \
+    CPPFLAGS="-I${INSTALL_DIR}/include  -I/usr/include" \
+    LDFLAGS="-L${INSTALL_DIR}/lib64 -L${INSTALL_DIR}/lib" \
+    ./configure \
+    --prefix=${INSTALL_DIR} \
+    --64
+
+RUN set -xe; \
+    make install \
+ && rm ${INSTALL_DIR}/lib/libz.a
+
+
+###############################################################################
 # OPENSSL
 # https://github.com/openssl/openssl/releases
 # Needs:

--- a/php-82/Dockerfile
+++ b/php-82/Dockerfile
@@ -70,6 +70,42 @@ RUN mkdir -p ${BUILD_DIR}  \
 
 
 ###############################################################################
+# ZLIB Build
+# https://github.com/madler/zlib/releases
+# Needed for:
+#   - openssl
+#   - curl
+#   - php
+# Used By:
+#   - xml2
+ENV VERSION_ZLIB=1.3
+ENV ZLIB_BUILD_DIR=${BUILD_DIR}/xml2
+
+RUN set -xe; \
+    mkdir -p ${ZLIB_BUILD_DIR}; \
+# Download and upack the source code
+    curl -Ls http://zlib.net/zlib-${VERSION_ZLIB}.tar.xz \
+  | tar xJC ${ZLIB_BUILD_DIR} --strip-components=1
+
+# Move into the unpackaged code directory
+WORKDIR ${ZLIB_BUILD_DIR}/
+
+# Configure the build
+RUN set -xe; \
+    make distclean \
+ && CFLAGS="" \
+    CPPFLAGS="-I${INSTALL_DIR}/include  -I/usr/include" \
+    LDFLAGS="-L${INSTALL_DIR}/lib64 -L${INSTALL_DIR}/lib" \
+    ./configure \
+    --prefix=${INSTALL_DIR} \
+    --64
+
+RUN set -xe; \
+    make install \
+ && rm ${INSTALL_DIR}/lib/libz.a
+
+
+###############################################################################
 # OPENSSL
 # https://github.com/openssl/openssl/releases
 # Needs:

--- a/php-83/Dockerfile
+++ b/php-83/Dockerfile
@@ -71,6 +71,42 @@ RUN mkdir -p ${BUILD_DIR}  \
 
 
 ###############################################################################
+# ZLIB Build
+# https://github.com/madler/zlib/releases
+# Needed for:
+#   - openssl
+#   - curl
+#   - php
+# Used By:
+#   - xml2
+ENV VERSION_ZLIB=1.3
+ENV ZLIB_BUILD_DIR=${BUILD_DIR}/xml2
+
+RUN set -xe; \
+    mkdir -p ${ZLIB_BUILD_DIR}; \
+# Download and upack the source code
+    curl -Ls http://zlib.net/zlib-${VERSION_ZLIB}.tar.xz \
+  | tar xJC ${ZLIB_BUILD_DIR} --strip-components=1
+
+# Move into the unpackaged code directory
+WORKDIR ${ZLIB_BUILD_DIR}/
+
+# Configure the build
+RUN set -xe; \
+    make distclean \
+ && CFLAGS="" \
+    CPPFLAGS="-I${INSTALL_DIR}/include  -I/usr/include" \
+    LDFLAGS="-L${INSTALL_DIR}/lib64 -L${INSTALL_DIR}/lib" \
+    ./configure \
+    --prefix=${INSTALL_DIR} \
+    --64
+
+RUN set -xe; \
+    make install \
+ && rm ${INSTALL_DIR}/lib/libz.a
+
+
+###############################################################################
 # OPENSSL
 # https://github.com/openssl/openssl/releases
 # Needs:


### PR DESCRIPTION
Just like in bref 1.x, because Amazon have not updated their version in a long time, and it has security issues.