### PR TITLE
Bump to cURL 8.4.0

### DIFF
--- a/php-80/Dockerfile
+++ b/php-80/Dockerfile
@@ -232,7 +232,7 @@ RUN make install
 # #   - libnghttp2
 # # Needed by:
 # #   - php
-ENV VERSION_CURL=8.3.0
+ENV VERSION_CURL=8.4.0
 ENV CURL_BUILD_DIR=${BUILD_DIR}/curl
 RUN set -xe; \
     mkdir -p ${CURL_BUILD_DIR}/bin; \

--- a/php-81/Dockerfile
+++ b/php-81/Dockerfile
@@ -233,7 +233,7 @@ RUN make install
 # #   - libnghttp2
 # # Needed by:
 # #   - php
-ENV VERSION_CURL=8.3.0
+ENV VERSION_CURL=8.4.0
 ENV CURL_BUILD_DIR=${BUILD_DIR}/curl
 RUN set -xe; \
     mkdir -p ${CURL_BUILD_DIR}/bin; \

--- a/php-82/Dockerfile
+++ b/php-82/Dockerfile
@@ -233,7 +233,7 @@ RUN make install
 # #   - libnghttp2
 # # Needed by:
 # #   - php
-ENV VERSION_CURL=8.3.0
+ENV VERSION_CURL=8.4.0
 ENV CURL_BUILD_DIR=${BUILD_DIR}/curl
 RUN set -xe; \
     mkdir -p ${CURL_BUILD_DIR}/bin; \

--- a/php-83/Dockerfile
+++ b/php-83/Dockerfile
@@ -234,7 +234,7 @@ RUN make install
 # #   - libnghttp2
 # # Needed by:
 # #   - php
-ENV VERSION_CURL=8.3.0
+ENV VERSION_CURL=8.4.0
 ENV CURL_BUILD_DIR=${BUILD_DIR}/curl
 RUN set -xe; \
     mkdir -p ${CURL_BUILD_DIR}/bin; \


### PR DESCRIPTION
Fixes [CVE-2023-38545](https://curl.se/docs/CVE-2023-38545.html) and [CVE-2023-38546](https://curl.se/docs/CVE-2023-38546.html).