### PR TITLE
Bump nghttp2 to 1.57.0

### DIFF
--- a/php-80/Dockerfile
+++ b/php-80/Dockerfile
@@ -206,7 +206,7 @@ RUN cmake  --build . --target install
 #   - libxml2
 # Needed by:
 #   - curl
-ENV VERSION_NGHTTP2=1.56.0
+ENV VERSION_NGHTTP2=1.57.0
 ENV NGHTTP2_BUILD_DIR=${BUILD_DIR}/nghttp2
 RUN set -xe; \
     mkdir -p ${NGHTTP2_BUILD_DIR}; \

--- a/php-81/Dockerfile
+++ b/php-81/Dockerfile
@@ -207,7 +207,7 @@ RUN cmake  --build . --target install
 #   - libxml2
 # Needed by:
 #   - curl
-ENV VERSION_NGHTTP2=1.56.0
+ENV VERSION_NGHTTP2=1.57.0
 ENV NGHTTP2_BUILD_DIR=${BUILD_DIR}/nghttp2
 RUN set -xe; \
     mkdir -p ${NGHTTP2_BUILD_DIR}; \

--- a/php-82/Dockerfile
+++ b/php-82/Dockerfile
@@ -207,7 +207,7 @@ RUN cmake  --build . --target install
 #   - libxml2
 # Needed by:
 #   - curl
-ENV VERSION_NGHTTP2=1.56.0
+ENV VERSION_NGHTTP2=1.57.0
 ENV NGHTTP2_BUILD_DIR=${BUILD_DIR}/nghttp2
 RUN set -xe; \
     mkdir -p ${NGHTTP2_BUILD_DIR}; \

--- a/php-83/Dockerfile
+++ b/php-83/Dockerfile
@@ -208,7 +208,7 @@ RUN cmake  --build . --target install
 #   - libxml2
 # Needed by:
 #   - curl
-ENV VERSION_NGHTTP2=1.56.0
+ENV VERSION_NGHTTP2=1.57.0
 ENV NGHTTP2_BUILD_DIR=${BUILD_DIR}/nghttp2
 RUN set -xe; \
     mkdir -p ${NGHTTP2_BUILD_DIR}; \


### PR DESCRIPTION
Fixes [CVE-2023-44487](https://github.com/nghttp2/nghttp2/security/advisories/GHSA-vx74-f528-fxqg).