### PR TITLE
Bumped actions versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,19 +28,19 @@ jobs:
 
             # See https://stackoverflow.com/questions/70312490/github-actions-runner-environment-doesnt-build-for-arm-images
             -   name: Set up QEMU to run ARM images (that were built with Depot)
-                uses: docker/setup-qemu-action@v2
+                uses: docker/setup-qemu-action@v3
 
             -   uses: depot/setup-action@v1
 
             -   name: Configure AWS credentials
-                uses: aws-actions/configure-aws-credentials@v3
+                uses: aws-actions/configure-aws-credentials@v4
                 with:
                     role-to-assume: arn:aws:iam::534081306603:role/bref-layer-publisher-github-actions
                     role-session-name: bref-layer-publisher-github-actions
                     aws-region: us-east-1
 
             -   name: Configure Docker Hub credentials
-                uses: docker/login-action@v2
+                uses: docker/login-action@v3
                 with:
                     username: ${{ secrets.DOCKER_USERNAME }}
                     password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,10 +50,10 @@ jobs:
 
             # See https://stackoverflow.com/questions/70312490/github-actions-runner-environment-doesnt-build-for-arm-images
             -   name: Set up QEMU to run ARM images (that were built with Depot)
-                uses: docker/setup-qemu-action@v2
+                uses: docker/setup-qemu-action@v3
 
             -   uses: depot/setup-action@v1
-            -   uses: docker/setup-buildx-action@v2
+            -   uses: docker/setup-buildx-action@v3
 
             # We use this action instead of running `make docker-images-php-XX` directly because it lets us
             # use OIDC authentication instead of a secret. Secrets can't be used in pull request builds.


### PR DESCRIPTION
Moves off of EOL node (16 -> 20) with known security vulnerabilities (already!).