### PR TITLE
feat: increasing memory limit to lambda max memory limit

### DIFF
--- a/layers/fpm/bref.ini
+++ b/layers/fpm/bref.ini
@@ -7,7 +7,7 @@ display_errors=0
 ; See https://github.com/php/php-src/blob/d91abf76e01a3c39424e8192ad049f473f900936/php.ini-production#L463
 error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
 
-memory_limit=3008M
+memory_limit=10240M
 
 opcache.enable=1
 

--- a/layers/function/bref.ini
+++ b/layers/function/bref.ini
@@ -6,7 +6,7 @@ display_errors=1
 ; See https://github.com/php/php-src/blob/d91abf76e01a3c39424e8192ad049f473f900936/php.ini-production#L463
 error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
 
-memory_limit=3008M
+memory_limit=10240M
 
 opcache.enable=1
 opcache.enable_cli=1


### PR DESCRIPTION
Discussion started on GitHub about why the memory limit was 3,008MB.

Turns out 3,008MB was the old limit, and the new maximum memory a lambda function can have is 10,240MB.

Source: https://aws.amazon.com/about-aws/whats-new/2020/12/aws-lambda-supports-10gb-memory-6-vcpu-cores-lambda-functions/

I don't think there are any reasons to not bump the value by default, but I could be wrong, PR open for discussion :wink: