### PR TITLE
Add file_exists check to prevent early require fatal

### DIFF
--- a/layers/bootstrap.php
+++ b/layers/bootstrap.php
@@ -1,10 +1,10 @@
 <?php declare(strict_types=1);
 
+$appRoot = getenv('LAMBDA_TASK_ROOT');
+
 if (getenv('BREF_AUTOLOAD_PATH')) {
     require getenv('BREF_AUTOLOAD_PATH');
-} else {
-    $appRoot = getenv('LAMBDA_TASK_ROOT');
-
+} elseif (file_exists($appRoot . '/vendor/autoload.php')) {
     require $appRoot . '/vendor/autoload.php';
 }
 


### PR DESCRIPTION
This PR is in relation to https://github.com/brefphp/constructs/issues/12

By checking for the file to exist before `require`ing it we allow the later thrown exception to flow out as intended.
