### PR TITLE
Tag Docker images for patch versions too

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     workflow_dispatch:
     # But the main use case is to release new layers when a release is created
     release:
-        types: [published]
+        types: [ published ]
 
 # Necessary to deploy to AWS using OIDC
 # https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services
@@ -25,6 +25,10 @@ jobs:
                     - arm
         steps:
             -   uses: actions/checkout@v4
+
+            -   name: Get the version
+                id: get_version
+                run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
 
             # See https://stackoverflow.com/questions/70312490/github-actions-runner-environment-doesnt-build-for-arm-images
             -   name: Set up QEMU to run ARM images (that were built with Depot)
@@ -66,6 +70,7 @@ jobs:
             -   run: make upload-to-docker-hub
                 env:
                     CPU: ${{ matrix.cpu }}
+                    DOCKER_TAG: ${{ steps.get_version.outputs.VERSION }}
 
     update-layer-versions:
         name: Update layer versions in brefphp/bref

--- a/Makefile
+++ b/Makefile
@@ -72,11 +72,16 @@ upload-layers-php-%:
 # Publish Docker images to Docker Hub.
 upload-to-docker-hub: upload-to-docker-hub-php-80 upload-to-docker-hub-php-81 upload-to-docker-hub-php-82 upload-to-docker-hub-php-83
 upload-to-docker-hub-php-%:
+    # Make sure we have defined the docker tag
+	(test $(DOCKER_TAG)) && echo "Tagging images with \"${DOCKER_TAG}\"" || echo "You have to define environment variable DOCKER_TAG"
+	test $(DOCKER_TAG)
+
 	for image in \
 	  "bref/${CPU_PREFIX}php-$*" "bref/${CPU_PREFIX}php-$*-fpm" "bref/${CPU_PREFIX}php-$*-console" \
 	  "bref/${CPU_PREFIX}build-php-$*" "bref/${CPU_PREFIX}php-$*-fpm-dev"; \
 	do \
 		docker tag $$image $$image:2 ; \
+		docker tag $$image $$image:${DOCKER_TAG} ; \
 		docker push $$image --all-tags ; \
 	done
 


### PR DESCRIPTION
So in Docker Hub we have tags:

- `latest`
- `2`
- `2.1.8`

Allowing users to pinpoint a specific version and control upgrades.