### PR TITLE
Installed xdebug with PHP 8.3.0

### DIFF
--- a/layers/fpm-dev/Dockerfile
+++ b/layers/fpm-dev/Dockerfile
@@ -10,8 +10,8 @@ ARG PHP_VERSION
 RUN mkdir -p /opt/bref/extensions
 
 # Install xdebug
-RUN if [ $PHP_VERSION != "83" ]; then pecl install xdebug; fi
-RUN if [ $PHP_VERSION != "83" ]; then cp $(php -r "echo ini_get('extension_dir');")/xdebug.so /opt/bref/extensions; fi
+RUN pecl install xdebug
+RUN cp $(php -r "echo ini_get('extension_dir');")/xdebug.so /opt/bref/extensions
 
 # Install Blackfire
 # https://blackfire.io/docs/up-and-running/installation?action=install&mode=full&version=latest&mode=full&location=server&os=manual&language=php#install-the-php-probe


### PR DESCRIPTION
When support for PHP 8.3.0beta1 was added in #91, PHP 8.3 was excluded from the xdebug installation.

So we have made sure to install xdebug with PHP 8.3.0.