### PR TITLE
curl 8.6.0

### DIFF
--- a/php-80/Dockerfile
+++ b/php-80/Dockerfile
@@ -228,7 +228,7 @@ RUN make install
 # https://github.com/rockdaboot/libpsl/releases
 # Needed by:
 #   - curl
-RUN yum install -y autoconf autoconf-archive
+RUN yum install -y autoconf
 ENV VERSION_LIBPSL=0.21.5
 ENV LIBPSL_BUILD_DIR=${BUILD_DIR}/libpsl
 RUN set -xe; \

--- a/php-80/Dockerfile
+++ b/php-80/Dockerfile
@@ -228,7 +228,6 @@ RUN make install
 # https://github.com/rockdaboot/libpsl/releases
 # Needed by:
 #   - curl
-RUN yum install -y autoconf
 ENV VERSION_LIBPSL=0.21.5
 ENV LIBPSL_BUILD_DIR=${BUILD_DIR}/libpsl
 RUN set -xe; \

--- a/php-80/Dockerfile
+++ b/php-80/Dockerfile
@@ -232,7 +232,7 @@ RUN make install
 # #   - libnghttp2
 # # Needed by:
 # #   - php
-ENV VERSION_CURL=8.5.0
+ENV VERSION_CURL=8.6.0
 ENV CURL_BUILD_DIR=${BUILD_DIR}/curl
 RUN set -xe; \
     mkdir -p ${CURL_BUILD_DIR}/bin; \

--- a/php-80/Dockerfile
+++ b/php-80/Dockerfile
@@ -223,6 +223,28 @@ RUN make install
 
 
 ###############################################################################
+# LIBPSL
+# This adds support for the public suffix list in curl.
+# https://github.com/rockdaboot/libpsl/releases
+# Needed by:
+#   - curl
+ENV VERSION_LIBPSL=0.21.5
+ENV LIBPSL_BUILD_DIR=${BUILD_DIR}/libpsl
+RUN set -xe; \
+    mkdir -p ${LIBPSL_BUILD_DIR}; \
+    curl -Ls https://github.com/rockdaboot/libpsl/archive/refs/tags/${VERSION_LIBPSL}.tar.gz \
+    | tar xzC ${LIBPSL_BUILD_DIR} --strip-components=1
+WORKDIR  ${LIBPSL_BUILD_DIR}/
+RUN ./autogen.sh && autoconf
+RUN CFLAGS="" \
+    CPPFLAGS="-I${INSTALL_DIR}/include -I/usr/include" \
+    LDFLAGS="-L${INSTALL_DIR}/lib64 -L${INSTALL_DIR}/lib" \
+    ./configure \
+    --prefix=${INSTALL_DIR}
+RUN make -j $(nproc) && make install
+
+
+###############################################################################
 # CURL
 # # https://github.com/curl/curl/releases
 # # Needs:

--- a/php-80/Dockerfile
+++ b/php-80/Dockerfile
@@ -228,6 +228,7 @@ RUN make install
 # https://github.com/rockdaboot/libpsl/releases
 # Needed by:
 #   - curl
+RUN yum install -y autoconf
 ENV VERSION_LIBPSL=0.21.5
 ENV LIBPSL_BUILD_DIR=${BUILD_DIR}/libpsl
 RUN set -xe; \

--- a/php-80/Dockerfile
+++ b/php-80/Dockerfile
@@ -228,7 +228,7 @@ RUN make install
 # https://github.com/rockdaboot/libpsl/releases
 # Needed by:
 #   - curl
-RUN yum install -y autoconf
+RUN yum install -y autoconf autoconf-archive
 ENV VERSION_LIBPSL=0.21.5
 ENV LIBPSL_BUILD_DIR=${BUILD_DIR}/libpsl
 RUN set -xe; \

--- a/php-80/Dockerfile
+++ b/php-80/Dockerfile
@@ -232,7 +232,7 @@ ENV VERSION_LIBPSL=0.21.5
 ENV LIBPSL_BUILD_DIR=${BUILD_DIR}/libpsl
 RUN set -xe; \
     mkdir -p ${LIBPSL_BUILD_DIR}; \
-    curl -Ls https://github.com/rockdaboot/libpsl/archive/refs/tags/${VERSION_LIBPSL}.tar.gz \
+    curl -Ls https://github.com/rockdaboot/libpsl/releases/download/${VERSION_LIBPSL}/libpsl-${VERSION_LIBPSL}.tar.gz \
     | tar xzC ${LIBPSL_BUILD_DIR} --strip-components=1
 WORKDIR  ${LIBPSL_BUILD_DIR}/
 RUN CFLAGS="" \

--- a/php-80/Dockerfile
+++ b/php-80/Dockerfile
@@ -235,7 +235,6 @@ RUN set -xe; \
     curl -Ls https://github.com/rockdaboot/libpsl/archive/refs/tags/${VERSION_LIBPSL}.tar.gz \
     | tar xzC ${LIBPSL_BUILD_DIR} --strip-components=1
 WORKDIR  ${LIBPSL_BUILD_DIR}/
-RUN ./autogen.sh && autoconf
 RUN CFLAGS="" \
     CPPFLAGS="-I${INSTALL_DIR}/include -I/usr/include" \
     LDFLAGS="-L${INSTALL_DIR}/lib64 -L${INSTALL_DIR}/lib" \

--- a/php-81/Dockerfile
+++ b/php-81/Dockerfile
@@ -236,7 +236,6 @@ RUN set -xe; \
     curl -Ls https://github.com/rockdaboot/libpsl/archive/refs/tags/${VERSION_LIBPSL}.tar.gz \
     | tar xzC ${LIBPSL_BUILD_DIR} --strip-components=1
 WORKDIR  ${LIBPSL_BUILD_DIR}/
-RUN ./autogen.sh && autoconf
 RUN CFLAGS="" \
     CPPFLAGS="-I${INSTALL_DIR}/include -I/usr/include" \
     LDFLAGS="-L${INSTALL_DIR}/lib64 -L${INSTALL_DIR}/lib" \

--- a/php-81/Dockerfile
+++ b/php-81/Dockerfile
@@ -233,7 +233,7 @@ ENV VERSION_LIBPSL=0.21.5
 ENV LIBPSL_BUILD_DIR=${BUILD_DIR}/libpsl
 RUN set -xe; \
     mkdir -p ${LIBPSL_BUILD_DIR}; \
-    curl -Ls https://github.com/rockdaboot/libpsl/archive/refs/tags/${VERSION_LIBPSL}.tar.gz \
+    curl -Ls https://github.com/rockdaboot/libpsl/releases/download/${VERSION_LIBPSL}/libpsl-${VERSION_LIBPSL}.tar.gz \
     | tar xzC ${LIBPSL_BUILD_DIR} --strip-components=1
 WORKDIR  ${LIBPSL_BUILD_DIR}/
 RUN CFLAGS="" \

--- a/php-81/Dockerfile
+++ b/php-81/Dockerfile
@@ -233,7 +233,7 @@ RUN make install
 # #   - libnghttp2
 # # Needed by:
 # #   - php
-ENV VERSION_CURL=8.5.0
+ENV VERSION_CURL=8.6.0
 ENV CURL_BUILD_DIR=${BUILD_DIR}/curl
 RUN set -xe; \
     mkdir -p ${CURL_BUILD_DIR}/bin; \

--- a/php-81/Dockerfile
+++ b/php-81/Dockerfile
@@ -229,7 +229,6 @@ RUN make install
 # https://github.com/rockdaboot/libpsl/releases
 # Needed by:
 #   - curl
-RUN yum install -y autoconf
 ENV VERSION_LIBPSL=0.21.5
 ENV LIBPSL_BUILD_DIR=${BUILD_DIR}/libpsl
 RUN set -xe; \

--- a/php-81/Dockerfile
+++ b/php-81/Dockerfile
@@ -229,7 +229,7 @@ RUN make install
 # https://github.com/rockdaboot/libpsl/releases
 # Needed by:
 #   - curl
-RUN yum install -y autoconf autoconf-archive
+RUN yum install -y autoconf
 ENV VERSION_LIBPSL=0.21.5
 ENV LIBPSL_BUILD_DIR=${BUILD_DIR}/libpsl
 RUN set -xe; \

--- a/php-81/Dockerfile
+++ b/php-81/Dockerfile
@@ -224,6 +224,28 @@ RUN make install
 
 
 ###############################################################################
+# LIBPSL
+# This adds support for the public suffix list in curl.
+# https://github.com/rockdaboot/libpsl/releases
+# Needed by:
+#   - curl
+ENV VERSION_LIBPSL=0.21.5
+ENV LIBPSL_BUILD_DIR=${BUILD_DIR}/libpsl
+RUN set -xe; \
+    mkdir -p ${LIBPSL_BUILD_DIR}; \
+    curl -Ls https://github.com/rockdaboot/libpsl/archive/refs/tags/${VERSION_LIBPSL}.tar.gz \
+    | tar xzC ${LIBPSL_BUILD_DIR} --strip-components=1
+WORKDIR  ${LIBPSL_BUILD_DIR}/
+RUN ./autogen.sh && autoconf
+RUN CFLAGS="" \
+    CPPFLAGS="-I${INSTALL_DIR}/include -I/usr/include" \
+    LDFLAGS="-L${INSTALL_DIR}/lib64 -L${INSTALL_DIR}/lib" \
+    ./configure \
+    --prefix=${INSTALL_DIR}
+RUN make -j $(nproc) && make install
+
+
+###############################################################################
 # CURL
 # # https://github.com/curl/curl/releases
 # # Needs:

--- a/php-81/Dockerfile
+++ b/php-81/Dockerfile
@@ -229,7 +229,7 @@ RUN make install
 # https://github.com/rockdaboot/libpsl/releases
 # Needed by:
 #   - curl
-RUN yum install -y autoconf
+RUN yum install -y autoconf autoconf-archive
 ENV VERSION_LIBPSL=0.21.5
 ENV LIBPSL_BUILD_DIR=${BUILD_DIR}/libpsl
 RUN set -xe; \

--- a/php-81/Dockerfile
+++ b/php-81/Dockerfile
@@ -229,6 +229,7 @@ RUN make install
 # https://github.com/rockdaboot/libpsl/releases
 # Needed by:
 #   - curl
+RUN yum install -y autoconf
 ENV VERSION_LIBPSL=0.21.5
 ENV LIBPSL_BUILD_DIR=${BUILD_DIR}/libpsl
 RUN set -xe; \

--- a/php-82/Dockerfile
+++ b/php-82/Dockerfile
@@ -236,7 +236,6 @@ RUN set -xe; \
     curl -Ls https://github.com/rockdaboot/libpsl/archive/refs/tags/${VERSION_LIBPSL}.tar.gz \
     | tar xzC ${LIBPSL_BUILD_DIR} --strip-components=1
 WORKDIR  ${LIBPSL_BUILD_DIR}/
-RUN ./autogen.sh && autoconf
 RUN CFLAGS="" \
     CPPFLAGS="-I${INSTALL_DIR}/include -I/usr/include" \
     LDFLAGS="-L${INSTALL_DIR}/lib64 -L${INSTALL_DIR}/lib" \

--- a/php-82/Dockerfile
+++ b/php-82/Dockerfile
@@ -233,7 +233,7 @@ ENV VERSION_LIBPSL=0.21.5
 ENV LIBPSL_BUILD_DIR=${BUILD_DIR}/libpsl
 RUN set -xe; \
     mkdir -p ${LIBPSL_BUILD_DIR}; \
-    curl -Ls https://github.com/rockdaboot/libpsl/archive/refs/tags/${VERSION_LIBPSL}.tar.gz \
+    curl -Ls https://github.com/rockdaboot/libpsl/releases/download/${VERSION_LIBPSL}/libpsl-${VERSION_LIBPSL}.tar.gz \
     | tar xzC ${LIBPSL_BUILD_DIR} --strip-components=1
 WORKDIR  ${LIBPSL_BUILD_DIR}/
 RUN CFLAGS="" \

--- a/php-82/Dockerfile
+++ b/php-82/Dockerfile
@@ -233,7 +233,7 @@ RUN make install
 # #   - libnghttp2
 # # Needed by:
 # #   - php
-ENV VERSION_CURL=8.5.0
+ENV VERSION_CURL=8.6.0
 ENV CURL_BUILD_DIR=${BUILD_DIR}/curl
 RUN set -xe; \
     mkdir -p ${CURL_BUILD_DIR}/bin; \

--- a/php-82/Dockerfile
+++ b/php-82/Dockerfile
@@ -229,7 +229,6 @@ RUN make install
 # https://github.com/rockdaboot/libpsl/releases
 # Needed by:
 #   - curl
-RUN yum install -y autoconf
 ENV VERSION_LIBPSL=0.21.5
 ENV LIBPSL_BUILD_DIR=${BUILD_DIR}/libpsl
 RUN set -xe; \

--- a/php-82/Dockerfile
+++ b/php-82/Dockerfile
@@ -229,7 +229,7 @@ RUN make install
 # https://github.com/rockdaboot/libpsl/releases
 # Needed by:
 #   - curl
-RUN yum install -y autoconf autoconf-archive
+RUN yum install -y autoconf
 ENV VERSION_LIBPSL=0.21.5
 ENV LIBPSL_BUILD_DIR=${BUILD_DIR}/libpsl
 RUN set -xe; \

--- a/php-82/Dockerfile
+++ b/php-82/Dockerfile
@@ -224,6 +224,28 @@ RUN make install
 
 
 ###############################################################################
+# LIBPSL
+# This adds support for the public suffix list in curl.
+# https://github.com/rockdaboot/libpsl/releases
+# Needed by:
+#   - curl
+ENV VERSION_LIBPSL=0.21.5
+ENV LIBPSL_BUILD_DIR=${BUILD_DIR}/libpsl
+RUN set -xe; \
+    mkdir -p ${LIBPSL_BUILD_DIR}; \
+    curl -Ls https://github.com/rockdaboot/libpsl/archive/refs/tags/${VERSION_LIBPSL}.tar.gz \
+    | tar xzC ${LIBPSL_BUILD_DIR} --strip-components=1
+WORKDIR  ${LIBPSL_BUILD_DIR}/
+RUN ./autogen.sh && autoconf
+RUN CFLAGS="" \
+    CPPFLAGS="-I${INSTALL_DIR}/include -I/usr/include" \
+    LDFLAGS="-L${INSTALL_DIR}/lib64 -L${INSTALL_DIR}/lib" \
+    ./configure \
+    --prefix=${INSTALL_DIR}
+RUN make -j $(nproc) && make install
+
+
+###############################################################################
 # CURL
 # # https://github.com/curl/curl/releases
 # # Needs:

--- a/php-82/Dockerfile
+++ b/php-82/Dockerfile
@@ -229,7 +229,7 @@ RUN make install
 # https://github.com/rockdaboot/libpsl/releases
 # Needed by:
 #   - curl
-RUN yum install -y autoconf
+RUN yum install -y autoconf autoconf-archive
 ENV VERSION_LIBPSL=0.21.5
 ENV LIBPSL_BUILD_DIR=${BUILD_DIR}/libpsl
 RUN set -xe; \

--- a/php-82/Dockerfile
+++ b/php-82/Dockerfile
@@ -229,6 +229,7 @@ RUN make install
 # https://github.com/rockdaboot/libpsl/releases
 # Needed by:
 #   - curl
+RUN yum install -y autoconf
 ENV VERSION_LIBPSL=0.21.5
 ENV LIBPSL_BUILD_DIR=${BUILD_DIR}/libpsl
 RUN set -xe; \

--- a/php-83/Dockerfile
+++ b/php-83/Dockerfile
@@ -236,7 +236,6 @@ RUN set -xe; \
     curl -Ls https://github.com/rockdaboot/libpsl/archive/refs/tags/${VERSION_LIBPSL}.tar.gz \
     | tar xzC ${LIBPSL_BUILD_DIR} --strip-components=1
 WORKDIR  ${LIBPSL_BUILD_DIR}/
-RUN ./autogen.sh && autoconf
 RUN CFLAGS="" \
     CPPFLAGS="-I${INSTALL_DIR}/include -I/usr/include" \
     LDFLAGS="-L${INSTALL_DIR}/lib64 -L${INSTALL_DIR}/lib" \

--- a/php-83/Dockerfile
+++ b/php-83/Dockerfile
@@ -233,7 +233,7 @@ ENV VERSION_LIBPSL=0.21.5
 ENV LIBPSL_BUILD_DIR=${BUILD_DIR}/libpsl
 RUN set -xe; \
     mkdir -p ${LIBPSL_BUILD_DIR}; \
-    curl -Ls https://github.com/rockdaboot/libpsl/archive/refs/tags/${VERSION_LIBPSL}.tar.gz \
+    curl -Ls https://github.com/rockdaboot/libpsl/releases/download/${VERSION_LIBPSL}/libpsl-${VERSION_LIBPSL}.tar.gz \
     | tar xzC ${LIBPSL_BUILD_DIR} --strip-components=1
 WORKDIR  ${LIBPSL_BUILD_DIR}/
 RUN CFLAGS="" \

--- a/php-83/Dockerfile
+++ b/php-83/Dockerfile
@@ -233,7 +233,7 @@ RUN make install
 # #   - libnghttp2
 # # Needed by:
 # #   - php
-ENV VERSION_CURL=8.5.0
+ENV VERSION_CURL=8.6.0
 ENV CURL_BUILD_DIR=${BUILD_DIR}/curl
 RUN set -xe; \
     mkdir -p ${CURL_BUILD_DIR}/bin; \

--- a/php-83/Dockerfile
+++ b/php-83/Dockerfile
@@ -229,7 +229,6 @@ RUN make install
 # https://github.com/rockdaboot/libpsl/releases
 # Needed by:
 #   - curl
-RUN yum install -y autoconf
 ENV VERSION_LIBPSL=0.21.5
 ENV LIBPSL_BUILD_DIR=${BUILD_DIR}/libpsl
 RUN set -xe; \

--- a/php-83/Dockerfile
+++ b/php-83/Dockerfile
@@ -229,7 +229,7 @@ RUN make install
 # https://github.com/rockdaboot/libpsl/releases
 # Needed by:
 #   - curl
-RUN yum install -y autoconf autoconf-archive
+RUN yum install -y autoconf
 ENV VERSION_LIBPSL=0.21.5
 ENV LIBPSL_BUILD_DIR=${BUILD_DIR}/libpsl
 RUN set -xe; \

--- a/php-83/Dockerfile
+++ b/php-83/Dockerfile
@@ -224,6 +224,28 @@ RUN make install
 
 
 ###############################################################################
+# LIBPSL
+# This adds support for the public suffix list in curl.
+# https://github.com/rockdaboot/libpsl/releases
+# Needed by:
+#   - curl
+ENV VERSION_LIBPSL=0.21.5
+ENV LIBPSL_BUILD_DIR=${BUILD_DIR}/libpsl
+RUN set -xe; \
+    mkdir -p ${LIBPSL_BUILD_DIR}; \
+    curl -Ls https://github.com/rockdaboot/libpsl/archive/refs/tags/${VERSION_LIBPSL}.tar.gz \
+    | tar xzC ${LIBPSL_BUILD_DIR} --strip-components=1
+WORKDIR  ${LIBPSL_BUILD_DIR}/
+RUN ./autogen.sh && autoconf
+RUN CFLAGS="" \
+    CPPFLAGS="-I${INSTALL_DIR}/include -I/usr/include" \
+    LDFLAGS="-L${INSTALL_DIR}/lib64 -L${INSTALL_DIR}/lib" \
+    ./configure \
+    --prefix=${INSTALL_DIR}
+RUN make -j $(nproc) && make install
+
+
+###############################################################################
 # CURL
 # # https://github.com/curl/curl/releases
 # # Needs:

--- a/php-83/Dockerfile
+++ b/php-83/Dockerfile
@@ -229,7 +229,7 @@ RUN make install
 # https://github.com/rockdaboot/libpsl/releases
 # Needed by:
 #   - curl
-RUN yum install -y autoconf
+RUN yum install -y autoconf autoconf-archive
 ENV VERSION_LIBPSL=0.21.5
 ENV LIBPSL_BUILD_DIR=${BUILD_DIR}/libpsl
 RUN set -xe; \

--- a/php-83/Dockerfile
+++ b/php-83/Dockerfile
@@ -229,6 +229,7 @@ RUN make install
 # https://github.com/rockdaboot/libpsl/releases
 # Needed by:
 #   - curl
+RUN yum install -y autoconf
 ENV VERSION_LIBPSL=0.21.5
 ENV LIBPSL_BUILD_DIR=${BUILD_DIR}/libpsl
 RUN set -xe; \


### PR DESCRIPTION
Prior to cURL 8.6.0, configure would silently skip when libpsl was missing, compiling without support for public suffix lists. For Bref v2 at least, I think it's probably a good idea to compile cURL with support for this, so I've added in a build step to compile libpsl.

For Bref v1 (https://github.com/brefphp/bref/pull/1729), I'm not sure it's such a good idea to start making what is arguably a breaking change, so I've added in the configure flag to continue to ignore the fact that libpsl is missing.