### PR TITLE
postgres 16.2

### DIFF
--- a/php-80/Dockerfile
+++ b/php-80/Dockerfile
@@ -336,7 +336,7 @@ RUN make install
 #   - OpenSSL
 # Needed by:
 #   - php
-ENV VERSION_POSTGRES=15.5
+ENV VERSION_POSTGRES=16.2
 ENV POSTGRES_BUILD_DIR=${BUILD_DIR}/postgres
 RUN set -xe; \
     mkdir -p ${POSTGRES_BUILD_DIR}/bin; \

--- a/php-80/Dockerfile
+++ b/php-80/Dockerfile
@@ -346,7 +346,7 @@ WORKDIR  ${POSTGRES_BUILD_DIR}/
 RUN CFLAGS="" \
     CPPFLAGS="-I${INSTALL_DIR}/include -I/usr/include" \
     LDFLAGS="-L${INSTALL_DIR}/lib64 -L${INSTALL_DIR}/lib" \
-    ./configure --prefix=${INSTALL_DIR} --with-openssl --without-readline
+    ./configure --prefix=${INSTALL_DIR} --with-openssl --without-icu --without-readline
 RUN cd ${POSTGRES_BUILD_DIR}/src/interfaces/libpq && make && make install
 RUN cd ${POSTGRES_BUILD_DIR}/src/bin/pg_config && make && make install
 RUN cd ${POSTGRES_BUILD_DIR}/src/backend && make generated-headers

--- a/php-81/Dockerfile
+++ b/php-81/Dockerfile
@@ -347,7 +347,7 @@ WORKDIR  ${POSTGRES_BUILD_DIR}/
 RUN CFLAGS="" \
     CPPFLAGS="-I${INSTALL_DIR}/include -I/usr/include" \
     LDFLAGS="-L${INSTALL_DIR}/lib64 -L${INSTALL_DIR}/lib" \
-    ./configure --prefix=${INSTALL_DIR} --with-openssl --without-readline
+    ./configure --prefix=${INSTALL_DIR} --with-openssl --without-icu --without-readline
 RUN cd ${POSTGRES_BUILD_DIR}/src/interfaces/libpq && make && make install
 RUN cd ${POSTGRES_BUILD_DIR}/src/bin/pg_config && make && make install
 RUN cd ${POSTGRES_BUILD_DIR}/src/backend && make generated-headers

--- a/php-81/Dockerfile
+++ b/php-81/Dockerfile
@@ -337,7 +337,7 @@ RUN make install
 #   - OpenSSL
 # Needed by:
 #   - php
-ENV VERSION_POSTGRES=15.5
+ENV VERSION_POSTGRES=16.2
 ENV POSTGRES_BUILD_DIR=${BUILD_DIR}/postgres
 RUN set -xe; \
     mkdir -p ${POSTGRES_BUILD_DIR}/bin; \

--- a/php-82/Dockerfile
+++ b/php-82/Dockerfile
@@ -347,7 +347,7 @@ WORKDIR  ${POSTGRES_BUILD_DIR}/
 RUN CFLAGS="" \
     CPPFLAGS="-I${INSTALL_DIR}/include -I/usr/include" \
     LDFLAGS="-L${INSTALL_DIR}/lib64 -L${INSTALL_DIR}/lib" \
-    ./configure --prefix=${INSTALL_DIR} --with-openssl --without-readline
+    ./configure --prefix=${INSTALL_DIR} --with-openssl --without-icu --without-readline
 RUN cd ${POSTGRES_BUILD_DIR}/src/interfaces/libpq && make && make install
 RUN cd ${POSTGRES_BUILD_DIR}/src/bin/pg_config && make && make install
 RUN cd ${POSTGRES_BUILD_DIR}/src/backend && make generated-headers

--- a/php-82/Dockerfile
+++ b/php-82/Dockerfile
@@ -337,7 +337,7 @@ RUN make install
 #   - OpenSSL
 # Needed by:
 #   - php
-ENV VERSION_POSTGRES=15.5
+ENV VERSION_POSTGRES=16.2
 ENV POSTGRES_BUILD_DIR=${BUILD_DIR}/postgres
 RUN set -xe; \
     mkdir -p ${POSTGRES_BUILD_DIR}/bin; \

--- a/php-83/Dockerfile
+++ b/php-83/Dockerfile
@@ -347,7 +347,7 @@ WORKDIR  ${POSTGRES_BUILD_DIR}/
 RUN CFLAGS="" \
     CPPFLAGS="-I${INSTALL_DIR}/include -I/usr/include" \
     LDFLAGS="-L${INSTALL_DIR}/lib64 -L${INSTALL_DIR}/lib" \
-    ./configure --prefix=${INSTALL_DIR} --with-openssl --without-readline
+    ./configure --prefix=${INSTALL_DIR} --with-openssl --without-icu --without-readline
 RUN cd ${POSTGRES_BUILD_DIR}/src/interfaces/libpq && make && make install
 RUN cd ${POSTGRES_BUILD_DIR}/src/bin/pg_config && make && make install
 RUN cd ${POSTGRES_BUILD_DIR}/src/backend && make generated-headers

--- a/php-83/Dockerfile
+++ b/php-83/Dockerfile
@@ -337,7 +337,7 @@ RUN make install
 #   - OpenSSL
 # Needed by:
 #   - php
-ENV VERSION_POSTGRES=15.5
+ENV VERSION_POSTGRES=16.2
 ENV POSTGRES_BUILD_DIR=${BUILD_DIR}/postgres
 RUN set -xe; \
     mkdir -p ${POSTGRES_BUILD_DIR}/bin; \


### PR DESCRIPTION
Note that the addition of `--without-icu` is not a change. The difference is just that `--with-icu` in postgres 15 was swapped out for `--without-icu` in postgres 16. Newer postgres clients are backwards compatible with older versions, so this change should be pretty safe. Notably, this new version (and also the corresponding 15.6 release) support OpenSSL 3.2, which has been bumped in a follow-up (#162).

---

Closes #144.