### PR TITLE
OpenSSL 3.2.1

### DIFF
--- a/php-81/Dockerfile
+++ b/php-81/Dockerfile
@@ -104,7 +104,7 @@ RUN set -xe; \
 #   - curl
 #   - php
 RUN yum install -y perl-IPC-Cmd
-ENV VERSION_OPENSSL=3.0.12
+ENV VERSION_OPENSSL=3.2.1
 ENV OPENSSL_BUILD_DIR=${BUILD_DIR}/openssl
 ENV CA_BUNDLE_SOURCE="https://curl.se/ca/cacert.pem"
 ENV CA_BUNDLE="${INSTALL_DIR}/bref/ssl/cert.pem"

--- a/php-82/Dockerfile
+++ b/php-82/Dockerfile
@@ -104,7 +104,7 @@ RUN set -xe; \
 #   - curl
 #   - php
 RUN yum install -y perl-IPC-Cmd
-ENV VERSION_OPENSSL=3.0.13
+ENV VERSION_OPENSSL=3.2.1
 ENV OPENSSL_BUILD_DIR=${BUILD_DIR}/openssl
 ENV CA_BUNDLE_SOURCE="https://curl.se/ca/cacert.pem"
 ENV CA_BUNDLE="${INSTALL_DIR}/bref/ssl/cert.pem"

--- a/php-83/Dockerfile
+++ b/php-83/Dockerfile
@@ -104,7 +104,7 @@ RUN set -xe; \
 #   - curl
 #   - php
 RUN yum install -y perl-IPC-Cmd
-ENV VERSION_OPENSSL=3.0.13
+ENV VERSION_OPENSSL=3.2.1
 ENV OPENSSL_BUILD_DIR=${BUILD_DIR}/openssl
 ENV CA_BUNDLE_SOURCE="https://curl.se/ca/cacert.pem"
 ENV CA_BUNDLE="${INSTALL_DIR}/bref/ssl/cert.pem"

--- a/tests/test_2_extensions.php
+++ b/tests/test_2_extensions.php
@@ -81,7 +81,7 @@ $extensions = [
     // https://github.com/brefphp/aws-lambda-layers/issues/42
     'curl-http2' => defined('CURL_HTTP_VERSION_2'),
     // Make sure we are not using the default AL2 OpenSSL version (7.79)
-    'curl-openssl' => str_starts_with(curl_version()['ssl_version'], 'OpenSSL/1.1.1') || str_starts_with(curl_version()['ssl_version'], 'OpenSSL/3.0'),
+    'curl-openssl' => str_starts_with(curl_version()['ssl_version'], 'OpenSSL/1.1.1') || str_starts_with(curl_version()['ssl_version'], 'OpenSSL/3'),
     // Check that the default certificate file exists
     // https://github.com/brefphp/aws-lambda-layers/issues/53
     'curl-openssl-certificates' => file_exists(openssl_get_cert_locations()['default_cert_file']),


### PR DESCRIPTION
Blocked by #161 which upgrades us to Postgres 16.2. Postgres 15.5 does not support OpenSSL 15.5 (#144), but Postgres 16.2 does (and so does the corresponding 15.6 Postgres release, actually). OpenSSL 3.2 should remediate some of the performance problems reported in https://github.com/brefphp/bref/issues/1528.