### PR TITLE
Bump libxml2 to 2.12.6

### DIFF
--- a/php-81/Dockerfile
+++ b/php-81/Dockerfile
@@ -141,7 +141,7 @@ RUN mkdir -p ${INSTALL_DIR}/bref/ssl && curl -Lk -o ${CA_BUNDLE} ${CA_BUNDLE_SOU
 # Needed by:
 #   - php
 #   - libnghttp2
-ENV VERSION_XML2=2.12.5
+ENV VERSION_XML2=2.12.6
 ENV XML2_BUILD_DIR=${BUILD_DIR}/xml2
 RUN set -xe; \
     mkdir -p ${XML2_BUILD_DIR}; \

--- a/php-82/Dockerfile
+++ b/php-82/Dockerfile
@@ -141,7 +141,7 @@ RUN mkdir -p ${INSTALL_DIR}/bref/ssl && curl -Lk -o ${CA_BUNDLE} ${CA_BUNDLE_SOU
 # Needed by:
 #   - php
 #   - libnghttp2
-ENV VERSION_XML2=2.12.5
+ENV VERSION_XML2=2.12.6
 ENV XML2_BUILD_DIR=${BUILD_DIR}/xml2
 RUN set -xe; \
     mkdir -p ${XML2_BUILD_DIR}; \

--- a/php-83/Dockerfile
+++ b/php-83/Dockerfile
@@ -141,7 +141,7 @@ RUN mkdir -p ${INSTALL_DIR}/bref/ssl && curl -Lk -o ${CA_BUNDLE} ${CA_BUNDLE_SOU
 # Needed by:
 #   - php
 #   - libnghttp2
-ENV VERSION_XML2=2.12.5
+ENV VERSION_XML2=2.12.6
 ENV XML2_BUILD_DIR=${BUILD_DIR}/xml2
 RUN set -xe; \
     mkdir -p ${XML2_BUILD_DIR}; \


### PR DESCRIPTION
FYI, there will be no corresponding PR for PHP 8.0 nor Bref v1 as they are using 2.11.7 and should not be switched to the 2.12.x series.