### PR TITLE
Add composer to the dev images

### DIFF
--- a/layers/fpm-dev/Dockerfile
+++ b/layers/fpm-dev/Dockerfile
@@ -37,6 +37,9 @@ EXPOSE 8000
 # Add `php/conf.dev.d` to the path where PHP looks for configuration files
 ENV PHP_INI_SCAN_DIR="/opt/bref/etc/php/conf.d:/var/task/php/conf.d:/var/task/php/conf.dev.d"
 
+# Add composer
+COPY --link --from=composer/composer:2-bin /composer /usr/bin/composer
+
 # Originally the entrypoint is `/lambda-entrypoint.sh` and CMD contains the handler name
 # We override the entrypoint to run our own logic
 ENTRYPOINT [ "/bref-entrypoint.sh" ]


### PR DESCRIPTION
Helpful to install prod dependencies before deploying (and run in the same env as prod).