### PR TITLE
Upgrade OpenSSL to 3.3.1

### DIFF
--- a/php-81/Dockerfile
+++ b/php-81/Dockerfile
@@ -104,7 +104,7 @@ RUN set -xe; \
 #   - curl
 #   - php
 RUN yum install -y perl-IPC-Cmd
-ENV VERSION_OPENSSL=3.3.0
+ENV VERSION_OPENSSL=3.3.1
 ENV OPENSSL_BUILD_DIR=${BUILD_DIR}/openssl
 ENV CA_BUNDLE_SOURCE="https://curl.se/ca/cacert.pem"
 ENV CA_BUNDLE="${INSTALL_DIR}/bref/ssl/cert.pem"

--- a/php-82/Dockerfile
+++ b/php-82/Dockerfile
@@ -104,7 +104,7 @@ RUN set -xe; \
 #   - curl
 #   - php
 RUN yum install -y perl-IPC-Cmd
-ENV VERSION_OPENSSL=3.3.0
+ENV VERSION_OPENSSL=3.3.1
 ENV OPENSSL_BUILD_DIR=${BUILD_DIR}/openssl
 ENV CA_BUNDLE_SOURCE="https://curl.se/ca/cacert.pem"
 ENV CA_BUNDLE="${INSTALL_DIR}/bref/ssl/cert.pem"

--- a/php-83/Dockerfile
+++ b/php-83/Dockerfile
@@ -104,7 +104,7 @@ RUN set -xe; \
 #   - curl
 #   - php
 RUN yum install -y perl-IPC-Cmd
-ENV VERSION_OPENSSL=3.3.0
+ENV VERSION_OPENSSL=3.3.1
 ENV OPENSSL_BUILD_DIR=${BUILD_DIR}/openssl
 ENV CA_BUNDLE_SOURCE="https://curl.se/ca/cacert.pem"
 ENV CA_BUNDLE="${INSTALL_DIR}/bref/ssl/cert.pem"


### PR DESCRIPTION
### Release Notes

* Support updated to oqs-provider 0.6.0
* Add demo for ECDH key exchange
* Fixes for various memory leaks
* Various build and behavioral fixes on VMS
* Various fixes in response to CVE-2024-4741
* Fix race for X509 store found by thread sanitizer
* Various bug fixes to the QUIC client
* Explicit setup of cpuid flags in the fips provider
* DSA size checking (CVE-2024-4603)
* Fix for an sm2 encryption implementation bug
* Addition of a linux-arm64ilp32-clang build target
* Various fixes for CVE-2024-2511
* Fix unconstrained session cache growth in TLSv1.3 (CVE-2024-2511)
* Fix unbounded memory growth when using no-cached-fetch
* Add atexit configuration option to using atexit() in libcrypto at build-time
* Fix sm4-xts aarch64 assembly implementation bug
* Fix compilation on Windows using icc
