### PR TITLE
Upgrade libsodium to 1.0.20

### DIFF
--- a/php-80/Dockerfile
+++ b/php-80/Dockerfile
@@ -318,7 +318,7 @@ ENV VERSION_LIBSODIUM=1.0.20
 ENV LIBSODIUM_BUILD_DIR=${BUILD_DIR}/libsodium
 RUN set -xe; \
     mkdir -p ${LIBSODIUM_BUILD_DIR}; \
-    curl -Ls https://github.com/jedisct1/libsodium/archive/${VERSION_LIBSODIUM}.tar.gz \
+    curl -Ls https://github.com/jedisct1/libsodium/archive/${VERSION_LIBSODIUM}-RELEASE.tar.gz \
   | tar xzC ${LIBSODIUM_BUILD_DIR} --strip-components=1
 WORKDIR  ${LIBSODIUM_BUILD_DIR}/
 RUN CFLAGS="" \

--- a/php-80/Dockerfile
+++ b/php-80/Dockerfile
@@ -314,7 +314,7 @@ RUN cmake  --build . --target install
 # https://github.com/jedisct1/libsodium/releases
 # Needed by:
 #   - php
-ENV VERSION_LIBSODIUM=1.0.19
+ENV VERSION_LIBSODIUM=1.0.20
 ENV LIBSODIUM_BUILD_DIR=${BUILD_DIR}/libsodium
 RUN set -xe; \
     mkdir -p ${LIBSODIUM_BUILD_DIR}; \

--- a/php-81/Dockerfile
+++ b/php-81/Dockerfile
@@ -319,7 +319,7 @@ ENV VERSION_LIBSODIUM=1.0.20
 ENV LIBSODIUM_BUILD_DIR=${BUILD_DIR}/libsodium
 RUN set -xe; \
     mkdir -p ${LIBSODIUM_BUILD_DIR}; \
-    curl -Ls https://github.com/jedisct1/libsodium/archive/${VERSION_LIBSODIUM}.tar.gz \
+    curl -Ls https://github.com/jedisct1/libsodium/archive/${VERSION_LIBSODIUM}-RELEASE.tar.gz \
   | tar xzC ${LIBSODIUM_BUILD_DIR} --strip-components=1
 WORKDIR  ${LIBSODIUM_BUILD_DIR}/
 RUN CFLAGS="" \

--- a/php-81/Dockerfile
+++ b/php-81/Dockerfile
@@ -315,7 +315,7 @@ RUN cmake  --build . --target install
 # https://github.com/jedisct1/libsodium/releases
 # Needed by:
 #   - php
-ENV VERSION_LIBSODIUM=1.0.19
+ENV VERSION_LIBSODIUM=1.0.20
 ENV LIBSODIUM_BUILD_DIR=${BUILD_DIR}/libsodium
 RUN set -xe; \
     mkdir -p ${LIBSODIUM_BUILD_DIR}; \

--- a/php-82/Dockerfile
+++ b/php-82/Dockerfile
@@ -319,7 +319,7 @@ ENV VERSION_LIBSODIUM=1.0.20
 ENV LIBSODIUM_BUILD_DIR=${BUILD_DIR}/libsodium
 RUN set -xe; \
     mkdir -p ${LIBSODIUM_BUILD_DIR}; \
-    curl -Ls https://github.com/jedisct1/libsodium/archive/${VERSION_LIBSODIUM}.tar.gz \
+    curl -Ls https://github.com/jedisct1/libsodium/archive/${VERSION_LIBSODIUM}-RELEASE.tar.gz \
   | tar xzC ${LIBSODIUM_BUILD_DIR} --strip-components=1
 WORKDIR  ${LIBSODIUM_BUILD_DIR}/
 RUN CFLAGS="" \

--- a/php-82/Dockerfile
+++ b/php-82/Dockerfile
@@ -315,7 +315,7 @@ RUN cmake  --build . --target install
 # https://github.com/jedisct1/libsodium/releases
 # Needed by:
 #   - php
-ENV VERSION_LIBSODIUM=1.0.19
+ENV VERSION_LIBSODIUM=1.0.20
 ENV LIBSODIUM_BUILD_DIR=${BUILD_DIR}/libsodium
 RUN set -xe; \
     mkdir -p ${LIBSODIUM_BUILD_DIR}; \

--- a/php-83/Dockerfile
+++ b/php-83/Dockerfile
@@ -319,7 +319,7 @@ ENV VERSION_LIBSODIUM=1.0.20
 ENV LIBSODIUM_BUILD_DIR=${BUILD_DIR}/libsodium
 RUN set -xe; \
     mkdir -p ${LIBSODIUM_BUILD_DIR}; \
-    curl -Ls https://github.com/jedisct1/libsodium/archive/${VERSION_LIBSODIUM}.tar.gz \
+    curl -Ls https://github.com/jedisct1/libsodium/archive/${VERSION_LIBSODIUM}-RELEASE.tar.gz \
   | tar xzC ${LIBSODIUM_BUILD_DIR} --strip-components=1
 WORKDIR  ${LIBSODIUM_BUILD_DIR}/
 RUN CFLAGS="" \

--- a/php-83/Dockerfile
+++ b/php-83/Dockerfile
@@ -315,7 +315,7 @@ RUN cmake  --build . --target install
 # https://github.com/jedisct1/libsodium/releases
 # Needed by:
 #   - php
-ENV VERSION_LIBSODIUM=1.0.19
+ENV VERSION_LIBSODIUM=1.0.20
 ENV LIBSODIUM_BUILD_DIR=${BUILD_DIR}/libsodium
 RUN set -xe; \
     mkdir -p ${LIBSODIUM_BUILD_DIR}; \


### PR DESCRIPTION
### Release Notes

* Building with `zig build` now requires Zig 0.12.
* When using the traditional build system, -O3 is used instead of -Ofast.
* Improved detection of the compiler flags required on aarch64.
* mproved compatibility with custom build systems on aarch64.
* apple-xcframework: VisionOS packages are not built if Xcode doesn't include that SDK.
* `crypto_kdf_hkdf_sha512_statebytes()` was added.
* When using Visual Studio, runtime CPU feature detection is now enabled on Windows/aarch64.
* There were issues with C++ guards affecting usage of libsodium using Swift on Windows. This has been fixed.
* Emscripten: `crypto_aead_aegis*()` functions are now exported in JavaScript builds
* Emscripten: unsupported `--memory-init-file` option has been removed.
* apple-xcframework: the minimal deployment target can be set to iOS 11+.
* .NET packages now include precompiled libraries for Windows/arm64, iOS, TvOS and Catalyst.
* .NET precompiled libraries now work on any CPUs, using only runtime feature detection.
* SYSV assembly should not be used when targeting Windows (reported by @meiyese, thanks!)
* Compatibility issues with LLVM 18 and AVX512 have been addressed.
* GitHub attestation build provenance are now added to NuGet packages.
* JavaScript tests can now use Bun as an alternative to Node.
