### PR TITLE
Upgrade PHP to 8.1.29, 8.2.20, 8.3.8

### DIFF
--- a/php-81/Dockerfile
+++ b/php-81/Dockerfile
@@ -4,7 +4,7 @@
 ARG IMAGE_VERSION_SUFFIX
 
 # https://www.php.net/downloads
-ARG VERSION_PHP=8.1.28
+ARG VERSION_PHP=8.1.29
 
 
 # Lambda uses a custom AMI named Amazon Linux 2

--- a/php-82/Dockerfile
+++ b/php-82/Dockerfile
@@ -4,7 +4,7 @@
 ARG IMAGE_VERSION_SUFFIX
 
 # https://www.php.net/downloads
-ARG VERSION_PHP=8.2.19
+ARG VERSION_PHP=8.2.20
 
 
 # Lambda uses a custom AMI named Amazon Linux 2

--- a/php-83/Dockerfile
+++ b/php-83/Dockerfile
@@ -4,7 +4,7 @@
 ARG IMAGE_VERSION_SUFFIX
 
 # https://www.php.net/downloads
-ARG VERSION_PHP=8.3.7
+ARG VERSION_PHP=8.3.8
 
 
 # Lambda uses a custom AMI named Amazon Linux 2


### PR DESCRIPTION
### PHP 8.1.29 Release Notes

- CGI:
  . Fixed bug GHSA-3qgc-jrrr-25jv (Bypass of CVE-2012-1823, Argument Injection
    in PHP-CGI). (CVE-2024-4577) (nielsdos)

- Filter:
  . Fixed bug GHSA-w8qr-v226-r27w (Filter bypass in filter_var FILTER_VALIDATE_URL).
    (CVE-2024-5458) (nielsdos)

- OpenSSL:
  . The openssl_private_decrypt function in PHP, when using PKCS1 padding
    (OPENSSL_PKCS1_PADDING, which is the default), is vulnerable to the Marvin Attack
    unless it is used with an OpenSSL version that includes the changes from this pull
    request: https://github.com/openssl/openssl/pull/13817 (rsa_pkcs1_implicit_rejection).
    These changes are part of OpenSSL 3.2 and have also been backported to stable
    versions of various Linux distributions, as well as to the PHP builds provided for
    Windows since the previous release. All distributors and builders should ensure that
    this version is used to prevent PHP from being vulnerable. (CVE-2024-2408)

- Standard:
  . Fixed bug GHSA-9fcc-425m-g385 (Bypass of CVE-2024-1874).
    (CVE-2024-5585) (nielsdos)

### PHP 8.2.20 Release Notes

- CGI:
  . Fixed buffer limit on Windows, replacing read call usage by _read.
    (David Carlier)
  . Fixed bug GHSA-3qgc-jrrr-25jv (Bypass of CVE-2012-1823, Argument Injection
    in PHP-CGI). (CVE-2024-4577) (nielsdos)

- CLI:
  . Fixed bug GH-14189 (PHP Interactive shell input state incorrectly handles
    quoted heredoc literals.). (nielsdos)

- Core:
  . Fixed bug GH-13970 (Incorrect validation of #[Attribute] flags type for
    non-compile-time expressions). (ilutov)
  . Fixed bug GH-14140 (Floating point bug in range operation on Apple Silicon
    hardware). (Derick, Saki)

- DOM:
  . Fix crashes when entity declaration is removed while still having entity
    references. (nielsdos)
  . Fix references not handled correctly in C14N. (nielsdos)
  . Fix crash when calling childNodes next() when iterator is exhausted.
    (nielsdos)
  . Fix crash in ParentNode::append() when dealing with a fragment
    containing text nodes. (nielsdos)

- FFI:
  . Fixed bug GH-14215 (Cannot use FFI::load on CRLF header file with
    apache2handler). (nielsdos)

- Filter:
  . Fixed bug GHSA-w8qr-v226-r27w (Filter bypass in filter_var FILTER_VALIDATE_URL).
    (CVE-2024-5458) (nielsdos)

- FPM:
  . Fix bug GH-14175 (Show decimal number instead of scientific notation in
    systemd status). (Benjamin Cremer)

- Hash:
  . ext/hash: Swap the checking order of `__has_builtin` and `__GNUC__`
    (Saki Takamachi)

- Intl:
  . Fixed build regression on systems without C++17 compilers. (Calvin Buckley,
    Peter Kokot)

- Ini:
  . Fixed bug GH-14100 (Corrected spelling mistake in php.ini files).
    (Marcus Xavier)

- MySQLnd:
  . Fix bug GH-14255 (mysqli_fetch_assoc reports error from
    nested query). (Kamil Tekiela)

- Opcache:
  . Fixed bug GH-14109 (Fix accidental persisting of internal class constant in
    shm). (ilutov)

- OpenSSL:
  . The openssl_private_decrypt function in PHP, when using PKCS1 padding
    (OPENSSL_PKCS1_PADDING, which is the default), is vulnerable to the Marvin Attack
    unless it is used with an OpenSSL version that includes the changes from this pull
    request: https://github.com/openssl/openssl/pull/13817 (rsa_pkcs1_implicit_rejection).
    These changes are part of OpenSSL 3.2 and have also been backported to stable
    versions of various Linux distributions, as well as to the PHP builds provided for
    Windows since the previous release. All distributors and builders should ensure that
    this version is used to prevent PHP from being vulnerable. (CVE-2024-2408)

- Standard:
  . Fixed bug GHSA-9fcc-425m-g385 (Bypass of CVE-2024-1874).
    (CVE-2024-5585) (nielsdos)

- XML:
  . Fixed bug GH-14124 (Segmentation fault with XML extension under certain
    memory limit). (nielsdos)

- XMLReader:
  . Fixed bug GH-14183 (XMLReader::open() can't be overridden). (nielsdos)

### PHP 8.3.8 Release Notes

- CGI:
  . Fixed buffer limit on Windows, replacing read call usage by _read.
    (David Carlier)
  . Fixed bug GHSA-3qgc-jrrr-25jv (Bypass of CVE-2012-1823, Argument Injection
    in PHP-CGI). (CVE-2024-4577) (nielsdos)    

- CLI:
  . Fixed bug GH-14189 (PHP Interactive shell input state incorrectly handles
    quoted heredoc literals.). (nielsdos)

- Core:
  . Fixed bug GH-13970 (Incorrect validation of #[Attribute] flags type for
    non-compile-time expressions). (ilutov)

- DOM:
  . Fix crashes when entity declaration is removed while still having entity
    references. (nielsdos)
  . Fix references not handled correctly in C14N. (nielsdos)
  . Fix crash when calling childNodes next() when iterator is exhausted.
    (nielsdos)
  . Fix crash in ParentNode::append() when dealing with a fragment
    containing text nodes. (nielsdos)

- Filter:
  . Fixed bug GHSA-w8qr-v226-r27w (Filter bypass in filter_var FILTER_VALIDATE_URL).
    (CVE-2024-5458) (nielsdos)

- FPM:
  . Fix bug GH-14175 (Show decimal number instead of scientific notation in
    systemd status). (Benjamin Cremer)

- Hash:
  . ext/hash: Swap the checking order of `__has_builtin` and `__GNUC__`
    (Saki Takamachi)

- Intl:
  . Fixed build regression on systems without C++17 compilers. (Calvin Buckley,
    Peter Kokot)

- MySQLnd:
  . Fix bug GH-14255 (mysqli_fetch_assoc reports error from
    nested query). (Kamil Tekiela)

- Opcache:
  . Fixed bug GH-14109 (Fix accidental persisting of internal class constant in
    shm). (ilutov)

- OpenSSL:
  . The openssl_private_decrypt function in PHP, when using PKCS1 padding
    (OPENSSL_PKCS1_PADDING, which is the default), is vulnerable to the Marvin Attack
    unless it is used with an OpenSSL version that includes the changes from this pull
    request: https://github.com/openssl/openssl/pull/13817 (rsa_pkcs1_implicit_rejection).
    These changes are part of OpenSSL 3.2 and have also been backported to stable
    versions of various Linux distributions, as well as to the PHP builds provided for
    Windows since the previous release. All distributors and builders should ensure that
    this version is used to prevent PHP from being vulnerable. (CVE-2024-2408)

- Standard:
  . Fixed bug GHSA-9fcc-425m-g385 (Bypass of CVE-2024-1874).
    (CVE-2024-5585) (nielsdos)        

- XML:
  . Fixed bug GH-14124 (Segmentation fault with XML extension under certain
    memory limit). (nielsdos)

- XMLReader:
  . Fixed bug GH-14183 (XMLReader::open() can't be overridden). (nielsdos)
