### PR TITLE
close #1369 increase the php-fpm log limit to match AWS Cloudwatch

### DIFF
--- a/layers/fpm/php-fpm.conf
+++ b/layers/fpm/php-fpm.conf
@@ -7,7 +7,10 @@ pid = /tmp/.bref/php-fpm.pid
 ;log_level = 'warning'
 
 ; New PHP 7.3 option that includes the maximum length when writing to stderr
-log_limit = 8192
+: See https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutLogEvents.html
+; and https://github.com/php/php-src/issues/9010#issuecomment-1184574379
+; We set it to the limit of a AWS Cloudwatch log otherwise, reaching this limit would hang the php-fpm process.
+log_limit = 1048575
 
 [default]
 pm = static


### PR DESCRIPTION
So that the php-fpm process will not hang when reaching log_limit (it can still reach but it's muchhh harder, and reaching it would anyway cause an error with AWS Cloudwatch )

<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.
-->
