### PR TITLE
PHP 8.2.22, 8.3.10, 8.4.0alpha4 and libxml2 2.13.3

### DIFF
--- a/php-82/Dockerfile
+++ b/php-82/Dockerfile
@@ -4,7 +4,7 @@
 ARG IMAGE_VERSION_SUFFIX
 
 # https://www.php.net/downloads
-ARG VERSION_PHP=8.2.21
+ARG VERSION_PHP=8.2.22
 
 
 # Lambda uses a custom AMI named Amazon Linux 2
@@ -141,7 +141,7 @@ RUN mkdir -p ${INSTALL_DIR}/bref/ssl && curl -Lk -o ${CA_BUNDLE} ${CA_BUNDLE_SOU
 # Needed by:
 #   - php
 #   - libnghttp2
-ENV VERSION_XML2=2.12.9
+ENV VERSION_XML2=2.13.3
 ENV XML2_BUILD_DIR=${BUILD_DIR}/xml2
 RUN set -xe; \
     mkdir -p ${XML2_BUILD_DIR}; \

--- a/php-83/Dockerfile
+++ b/php-83/Dockerfile
@@ -4,7 +4,7 @@
 ARG IMAGE_VERSION_SUFFIX
 
 # https://www.php.net/downloads
-ARG VERSION_PHP=8.3.9
+ARG VERSION_PHP=8.3.10
 
 
 # Lambda uses a custom AMI named Amazon Linux 2
@@ -141,7 +141,7 @@ RUN mkdir -p ${INSTALL_DIR}/bref/ssl && curl -Lk -o ${CA_BUNDLE} ${CA_BUNDLE_SOU
 # Needed by:
 #   - php
 #   - libnghttp2
-ENV VERSION_XML2=2.12.9
+ENV VERSION_XML2=2.13.3
 ENV XML2_BUILD_DIR=${BUILD_DIR}/xml2
 RUN set -xe; \
     mkdir -p ${XML2_BUILD_DIR}; \

--- a/php-84/Dockerfile
+++ b/php-84/Dockerfile
@@ -5,7 +5,7 @@ ARG IMAGE_VERSION_SUFFIX
 
 # https://www.php.net/downloads
 ARG RELEASE_USER_PHP=saki
-ARG VERSION_PHP=8.4.0alpha3
+ARG VERSION_PHP=8.4.0alpha4
 
 
 # Lambda uses a custom AMI named Amazon Linux 2

--- a/php-84/Dockerfile
+++ b/php-84/Dockerfile
@@ -4,8 +4,8 @@
 ARG IMAGE_VERSION_SUFFIX
 
 # https://www.php.net/downloads
-ARG RELEASE_USER_PHP=calvinb
-ARG VERSION_PHP=8.4.0alpha2
+ARG RELEASE_USER_PHP=saki
+ARG VERSION_PHP=8.4.0alpha3
 
 
 # Lambda uses a custom AMI named Amazon Linux 2
@@ -142,7 +142,7 @@ RUN mkdir -p ${INSTALL_DIR}/bref/ssl && curl -Lk -o ${CA_BUNDLE} ${CA_BUNDLE_SOU
 # Needed by:
 #   - php
 #   - libnghttp2
-ENV VERSION_XML2=2.12.9
+ENV VERSION_XML2=2.13.3
 ENV XML2_BUILD_DIR=${BUILD_DIR}/xml2
 RUN set -xe; \
     mkdir -p ${XML2_BUILD_DIR}; \


### PR DESCRIPTION
PHP 8.2.22, 8.3.10, 8.4.0alpha4 were released today, and libxml2 2.13.3 is the latest version. The 2.13.x series of libxml2 is not compatible with PHP older than 8.2.22 (including 8.0.x, 8.1.x), 8.3.x older than 8.3.10, and 8.4.x older than alpha2.