### PR TITLE
Upgrade to cURL 8.9.1

### DIFF
--- a/php-80/Dockerfile
+++ b/php-80/Dockerfile
@@ -253,7 +253,7 @@ RUN make -j $(nproc) && make install
 # #   - libnghttp2
 # # Needed by:
 # #   - php
-ENV VERSION_CURL=8.9.0
+ENV VERSION_CURL=8.9.1
 ENV CURL_BUILD_DIR=${BUILD_DIR}/curl
 RUN set -xe; \
     mkdir -p ${CURL_BUILD_DIR}/bin; \

--- a/php-81/Dockerfile
+++ b/php-81/Dockerfile
@@ -254,7 +254,7 @@ RUN make -j $(nproc) && make install
 # #   - libnghttp2
 # # Needed by:
 # #   - php
-ENV VERSION_CURL=8.9.0
+ENV VERSION_CURL=8.9.1
 ENV CURL_BUILD_DIR=${BUILD_DIR}/curl
 RUN set -xe; \
     mkdir -p ${CURL_BUILD_DIR}/bin; \

--- a/php-82/Dockerfile
+++ b/php-82/Dockerfile
@@ -254,7 +254,7 @@ RUN make -j $(nproc) && make install
 # #   - libnghttp2
 # # Needed by:
 # #   - php
-ENV VERSION_CURL=8.9.0
+ENV VERSION_CURL=8.9.1
 ENV CURL_BUILD_DIR=${BUILD_DIR}/curl
 RUN set -xe; \
     mkdir -p ${CURL_BUILD_DIR}/bin; \

--- a/php-83/Dockerfile
+++ b/php-83/Dockerfile
@@ -254,7 +254,7 @@ RUN make -j $(nproc) && make install
 # #   - libnghttp2
 # # Needed by:
 # #   - php
-ENV VERSION_CURL=8.9.0
+ENV VERSION_CURL=8.9.1
 ENV CURL_BUILD_DIR=${BUILD_DIR}/curl
 RUN set -xe; \
     mkdir -p ${CURL_BUILD_DIR}/bin; \

--- a/php-84/Dockerfile
+++ b/php-84/Dockerfile
@@ -255,7 +255,7 @@ RUN make -j $(nproc) && make install
 # #   - libnghttp2
 # # Needed by:
 # #   - php
-ENV VERSION_CURL=8.9.0
+ENV VERSION_CURL=8.9.1
 ENV CURL_BUILD_DIR=${BUILD_DIR}/curl
 RUN set -xe; \
     mkdir -p ${CURL_BUILD_DIR}/bin; \


### PR DESCRIPTION
cURL 8.9.1 was released today with some important bug fixes and security fix. It is compatible with all PHP versions Bref supports.