### PR TITLE
Enable OpenSSL legacy providers support

### DIFF
--- a/php-80/Dockerfile
+++ b/php-80/Dockerfile
@@ -120,6 +120,7 @@ RUN CFLAGS="" \
         --openssldir=${INSTALL_DIR}/bref/ssl \
         --release \
         enable-tls1_3 \
+        enable-legacy \
         no-tests \
         shared \
         zlib
@@ -471,6 +472,7 @@ RUN pecl install APCu
 # Now we copy everything we need for the layers into /bref-layer (which will be used for the real /opt later)
 RUN mkdir -p /bref-layer/bin \
 &&  mkdir -p /bref-layer/lib \
+&&  mkdir -p /bref-layer/lib/ossl-modules \
 &&  mkdir -p /bref-layer/bref/extensions \
 &&  mkdir -p /bref-layer/bref/ssl
 
@@ -498,6 +500,8 @@ RUN cp ${CA_BUNDLE} /bref-layer/bref/ssl/cert.pem
 # Copy the OpenSSL config
 RUN cp ${INSTALL_DIR}/bref/ssl/openssl.cnf /bref-layer/bref/ssl/openssl.cnf
 
+# Copy the OpenSSL modules
+RUN cp /tmp/build/openssl/providers/legacy.so /bref-layer/lib/ossl-modules/legacy.so
 
 # ---------------------------------------------------------------
 # Start from a clean image to copy only the files we need

--- a/php-81/Dockerfile
+++ b/php-81/Dockerfile
@@ -121,6 +121,7 @@ RUN CFLAGS="" \
         --openssldir=${INSTALL_DIR}/bref/ssl \
         --release \
         enable-tls1_3 \
+        enable-legacy \
         no-tests \
         shared \
         zlib
@@ -472,6 +473,7 @@ RUN pecl install APCu
 # Now we copy everything we need for the layers into /bref-layer (which will be used for the real /opt later)
 RUN mkdir -p /bref-layer/bin \
 &&  mkdir -p /bref-layer/lib \
+&&  mkdir -p /bref-layer/lib/ossl-modules \
 &&  mkdir -p /bref-layer/bref/extensions \
 &&  mkdir -p /bref-layer/bref/ssl
 
@@ -499,6 +501,8 @@ RUN cp ${CA_BUNDLE} /bref-layer/bref/ssl/cert.pem
 # Copy the OpenSSL config
 RUN cp ${INSTALL_DIR}/bref/ssl/openssl.cnf /bref-layer/bref/ssl/openssl.cnf
 
+# Copy the OpenSSL modules
+RUN cp /tmp/build/openssl/providers/legacy.so /bref-layer/lib/ossl-modules/legacy.so
 
 # ---------------------------------------------------------------
 # Start from a clean image to copy only the files we need

--- a/php-82/Dockerfile
+++ b/php-82/Dockerfile
@@ -121,6 +121,7 @@ RUN CFLAGS="" \
         --openssldir=${INSTALL_DIR}/bref/ssl \
         --release \
         enable-tls1_3 \
+        enable-legacy \
         no-tests \
         shared \
         zlib
@@ -491,6 +492,7 @@ RUN pecl install APCu
 # Now we copy everything we need for the layers into /bref-layer (which will be used for the real /opt later)
 RUN mkdir -p /bref-layer/bin \
 &&  mkdir -p /bref-layer/lib \
+&&  mkdir -p /bref-layer/lib/ossl-modules \
 &&  mkdir -p /bref-layer/bref/extensions \
 &&  mkdir -p /bref-layer/bref/ssl
 
@@ -518,6 +520,8 @@ RUN cp ${CA_BUNDLE} /bref-layer/bref/ssl/cert.pem
 # Copy the OpenSSL config
 RUN cp ${INSTALL_DIR}/bref/ssl/openssl.cnf /bref-layer/bref/ssl/openssl.cnf
 
+# Copy the OpenSSL modules
+RUN cp /tmp/build/openssl/providers/legacy.so /bref-layer/lib/ossl-modules/legacy.so
 
 # ---------------------------------------------------------------
 # Start from a clean image to copy only the files we need

--- a/php-83/Dockerfile
+++ b/php-83/Dockerfile
@@ -121,6 +121,7 @@ RUN CFLAGS="" \
         --openssldir=${INSTALL_DIR}/bref/ssl \
         --release \
         enable-tls1_3 \
+        enable-legacy \
         no-tests \
         shared \
         zlib
@@ -491,6 +492,7 @@ RUN pecl install APCu
 # Now we copy everything we need for the layers into /bref-layer (which will be used for the real /opt later)
 RUN mkdir -p /bref-layer/bin \
 &&  mkdir -p /bref-layer/lib \
+&&  mkdir -p /bref-layer/lib/ossl-modules \
 &&  mkdir -p /bref-layer/bref/extensions \
 &&  mkdir -p /bref-layer/bref/ssl
 
@@ -518,6 +520,8 @@ RUN cp ${CA_BUNDLE} /bref-layer/bref/ssl/cert.pem
 # Copy the OpenSSL config
 RUN cp ${INSTALL_DIR}/bref/ssl/openssl.cnf /bref-layer/bref/ssl/openssl.cnf
 
+# Copy the OpenSSL modules
+RUN cp /tmp/build/openssl/providers/legacy.so /bref-layer/lib/ossl-modules/legacy.so
 
 # ---------------------------------------------------------------
 # Start from a clean image to copy only the files we need

--- a/php-84/Dockerfile
+++ b/php-84/Dockerfile
@@ -122,6 +122,7 @@ RUN CFLAGS="" \
         --openssldir=${INSTALL_DIR}/bref/ssl \
         --release \
         enable-tls1_3 \
+        enable-legacy \
         no-tests \
         shared \
         zlib
@@ -494,6 +495,7 @@ RUN pecl install APCu
 # Now we copy everything we need for the layers into /bref-layer (which will be used for the real /opt later)
 RUN mkdir -p /bref-layer/bin \
 &&  mkdir -p /bref-layer/lib \
+&&  mkdir -p /bref-layer/lib/ossl-modules \
 &&  mkdir -p /bref-layer/bref/extensions \
 &&  mkdir -p /bref-layer/bref/ssl
 
@@ -521,6 +523,8 @@ RUN cp ${CA_BUNDLE} /bref-layer/bref/ssl/cert.pem
 # Copy the OpenSSL config
 RUN cp ${INSTALL_DIR}/bref/ssl/openssl.cnf /bref-layer/bref/ssl/openssl.cnf
 
+# Copy the OpenSSL modules
+RUN cp /tmp/build/openssl/providers/legacy.so /bref-layer/lib/ossl-modules/legacy.so
 
 # ---------------------------------------------------------------
 # Start from a clean image to copy only the files we need


### PR DESCRIPTION
#### Overview
This pull request introduces a modification to the build process to include the legacy module (`legacy.so`) in the OpenSSL installation. This change is essential for enabling certain legacy ciphering algorithms that might still be required for specific integrations.

#### Key Changes
- **Build Flag Addition**: Added the `enable-legacy` flag in the OpenSSL build process. This flag allows OpenSSL to compile and include legacy cryptographic algorithms.
- **Legacy Module Inclusion**: The `legacy.so` file is now copied into the final build. This enables runtime configuration of OpenSSL to use legacy ciphers.
- **Use Case**: The primary motivation for this change is the need to support the RC4 algorithm, which is still required in some legacy systems and integrations.

#### Important Notes
- **Legacy Algorithms Not Loaded by Default**: Legacy algorithms are not enabled by default in the OpenSSL runtime. To load them, you must configure OpenSSL through environment variables:
  1. Set the environment variable `OPENSSL_MODULES` to point OpenSSL to the location of additional modules:
     ```bash
     OPENSSL_MODULES="/opt/lib/ossl-modules"
     ```
  2. Create a custom OpenSSL configuration file with the following content to activate both the default and legacy providers:
     ```ini
     openssl_conf = openssl_init

     [openssl_init]
     providers = provider_sect

     [provider_sect]
     default = default_sect
     legacy = legacy_sect

     [default_sect]
     activate = 1

     [legacy_sect]
     activate = 1
     ```
  3. Point OpenSSL to use the custom configuration file by setting the `OPENSSL_CONF` environment variable:
     ```bash
     OPENSSL_CONF="{path to custom openssl config file}"
     ```

#### Impact
By including the legacy module and providing instructions on how to enable legacy algorithms, this change ensures that applications requiring older encryption methods can function correctly without significant changes to their cryptographic dependencies.
