### PR TITLE
PHP 8.4.0 RC2

### DIFF
--- a/php-84/Dockerfile
+++ b/php-84/Dockerfile
@@ -5,7 +5,7 @@ ARG IMAGE_VERSION_SUFFIX
 
 # https://www.php.net/downloads
 ARG RELEASE_USER_PHP=saki
-ARG VERSION_PHP=8.4.0RC1
+ARG VERSION_PHP=8.4.0RC2
 
 
 # Lambda uses a custom AMI named Amazon Linux 2


### PR DESCRIPTION
PHP 8.4.0 RC2 support - see below for changes:
https://github.com/php/php-src/blob/php-8.4.0RC2/NEWS 