### PR TITLE
Enable FFI extension

### DIFF
--- a/php-80/Dockerfile
+++ b/php-80/Dockerfile
@@ -18,8 +18,7 @@ RUN set -xe \
     # Download yum repository data to cache
  && yum makecache \
     # Install default development tools (gcc, make, etc)
- && yum groupinstall -y "Development Tools" --setopt=group_package_types=mandatory,default \
- && yum install -y libffi libffi-devel
+ && yum groupinstall -y "Development Tools" --setopt=group_package_types=mandatory,default
 
 
 # The default version of cmake is 2.8.12. We need cmake to build a few of
@@ -381,8 +380,8 @@ RUN make && make install
 # libicu-devel : needed for intl
 # libxslt-devel : needed for the XSL extension
 # sqlite-devel : Since PHP 7.4 this must be installed (https://github.com/php/php-src/blob/99b8e67615159fc600a615e1e97f2d1cf18f14cb/UPGRADING#L616-L619)
-RUN LD_LIBRARY_PATH= yum install -y readline-devel gettext-devel libicu-devel libxslt-devel sqlite-devel
-
+# libffi-devel : needed for the FFI extension
+RUN LD_LIBRARY_PATH= yum install -y readline-devel gettext-devel libicu-devel libxslt-devel sqlite-devel libffi-devel
 
 # Note: this variable is used when building extra/custom extensions, do not remove
 ENV PHP_BUILD_DIR=/tmp/php

--- a/php-80/Dockerfile
+++ b/php-80/Dockerfile
@@ -18,7 +18,8 @@ RUN set -xe \
     # Download yum repository data to cache
  && yum makecache \
     # Install default development tools (gcc, make, etc)
- && yum groupinstall -y "Development Tools" --setopt=group_package_types=mandatory,default
+ && yum groupinstall -y "Development Tools" --setopt=group_package_types=mandatory,default \
+ && yum install -y libffi libffi-devel
 
 
 # The default version of cmake is 2.8.12. We need cmake to build a few of
@@ -449,6 +450,7 @@ RUN CFLAGS="-fstack-protector-strong -fpic -fpie -O3 -I${INSTALL_DIR}/include -I
         --enable-intl=shared \
         --enable-soap \
         --with-xsl=${INSTALL_DIR} \
+        --with-ffi \
         # necessary for `pecl` to work (to install PHP extensions)
         --with-pear \
         # extra compilation flags

--- a/php-81/Dockerfile
+++ b/php-81/Dockerfile
@@ -18,7 +18,8 @@ RUN set -xe \
     # Download yum repository data to cache
  && yum makecache \
     # Install default development tools (gcc, make, etc)
- && yum groupinstall -y "Development Tools" --setopt=group_package_types=mandatory,default
+ && yum groupinstall -y "Development Tools" --setopt=group_package_types=mandatory,default \
+ && yum install -y libffi libffi-devel
 
 
 # The default version of cmake is 2.8.12. We need cmake to build a few of
@@ -470,6 +471,7 @@ RUN CFLAGS="-fstack-protector-strong -fpic -fpie -O3 -I${INSTALL_DIR}/include -I
         --enable-intl=shared \
         --enable-soap \
         --with-xsl=${INSTALL_DIR} \
+        --with-ffi \
         # necessary for `pecl` to work (to install PHP extensions)
         --with-pear \
         # extra compilation flags

--- a/php-81/Dockerfile
+++ b/php-81/Dockerfile
@@ -18,8 +18,7 @@ RUN set -xe \
     # Download yum repository data to cache
  && yum makecache \
     # Install default development tools (gcc, make, etc)
- && yum groupinstall -y "Development Tools" --setopt=group_package_types=mandatory,default \
- && yum install -y libffi libffi-devel
+ && yum groupinstall -y "Development Tools" --setopt=group_package_types=mandatory,default
 
 
 # The default version of cmake is 2.8.12. We need cmake to build a few of
@@ -402,7 +401,8 @@ RUN make && make install
 # gettext-devel : needed for the --with-gettext flag
 # libicu-devel : needed for intl
 # libxslt-devel : needed for the XSL extension
-RUN LD_LIBRARY_PATH= yum install -y readline-devel gettext-devel libicu-devel libxslt-devel
+# libffi-devel : needed for the FFI extension
+RUN LD_LIBRARY_PATH= yum install -y readline-devel gettext-devel libicu-devel libxslt-devel libffi-devel
 
 
 # Note: this variable is used when building extra/custom extensions, do not remove

--- a/php-82/Dockerfile
+++ b/php-82/Dockerfile
@@ -18,7 +18,8 @@ RUN set -xe \
     # Download yum repository data to cache
  && yum makecache \
     # Install default development tools (gcc, make, etc)
- && yum groupinstall -y "Development Tools" --setopt=group_package_types=mandatory,default
+ && yum groupinstall -y "Development Tools" --setopt=group_package_types=mandatory,default \
+ && yum install -y libffi libffi-devel
 
 
 # The default version of cmake is 2.8.12. We need cmake to build a few of
@@ -470,6 +471,7 @@ RUN CFLAGS="-fstack-protector-strong -fpic -fpie -O3 -I${INSTALL_DIR}/include -I
         --enable-intl=shared \
         --enable-soap \
         --with-xsl=${INSTALL_DIR} \
+        --with-ffi \
         # necessary for `pecl` to work (to install PHP extensions)
         --with-pear \
         # extra compilation flags

--- a/php-82/Dockerfile
+++ b/php-82/Dockerfile
@@ -18,8 +18,7 @@ RUN set -xe \
     # Download yum repository data to cache
  && yum makecache \
     # Install default development tools (gcc, make, etc)
- && yum groupinstall -y "Development Tools" --setopt=group_package_types=mandatory,default \
- && yum install -y libffi libffi-devel
+ && yum groupinstall -y "Development Tools" --setopt=group_package_types=mandatory,default
 
 
 # The default version of cmake is 2.8.12. We need cmake to build a few of
@@ -402,7 +401,8 @@ RUN make && make install
 # gettext-devel : needed for the --with-gettext flag
 # libicu-devel : needed for intl
 # libxslt-devel : needed for the XSL extension
-RUN LD_LIBRARY_PATH= yum install -y readline-devel gettext-devel libicu-devel libxslt-devel
+# libffi-devel : needed for the FFI extension
+RUN LD_LIBRARY_PATH= yum install -y readline-devel gettext-devel libicu-devel libxslt-devel libffi-devel
 
 
 # Note: this variable is used when building extra/custom extensions, do not remove

--- a/php-83/Dockerfile
+++ b/php-83/Dockerfile
@@ -18,7 +18,8 @@ RUN set -xe \
     # Download yum repository data to cache
  && yum makecache \
     # Install default development tools (gcc, make, etc)
- && yum groupinstall -y "Development Tools" --setopt=group_package_types=mandatory,default
+ && yum groupinstall -y "Development Tools" --setopt=group_package_types=mandatory,default \
+ && yum install -y libffi libffi-devel
 
 
 # The default version of cmake is 2.8.12. We need cmake to build a few of
@@ -470,6 +471,7 @@ RUN CFLAGS="-fstack-protector-strong -fpic -fpie -O3 -I${INSTALL_DIR}/include -I
         --enable-intl=shared \
         --enable-soap \
         --with-xsl=${INSTALL_DIR} \
+        --with-ffi \
         # necessary for `pecl` to work (to install PHP extensions)
         --with-pear \
         # extra compilation flags

--- a/php-83/Dockerfile
+++ b/php-83/Dockerfile
@@ -18,8 +18,7 @@ RUN set -xe \
     # Download yum repository data to cache
  && yum makecache \
     # Install default development tools (gcc, make, etc)
- && yum groupinstall -y "Development Tools" --setopt=group_package_types=mandatory,default \
- && yum install -y libffi libffi-devel
+ && yum groupinstall -y "Development Tools" --setopt=group_package_types=mandatory,default
 
 
 # The default version of cmake is 2.8.12. We need cmake to build a few of
@@ -402,7 +401,8 @@ RUN make && make install
 # gettext-devel : needed for the --with-gettext flag
 # libicu-devel : needed for intl
 # libxslt-devel : needed for the XSL extension
-RUN LD_LIBRARY_PATH= yum install -y readline-devel gettext-devel libicu-devel libxslt-devel
+# libffi-devel : needed for the FFI extension
+RUN LD_LIBRARY_PATH= yum install -y readline-devel gettext-devel libicu-devel libxslt-devel libffi-devel
 
 
 # Note: this variable is used when building extra/custom extensions, do not remove

--- a/php-84/Dockerfile
+++ b/php-84/Dockerfile
@@ -18,7 +18,8 @@ RUN set -xe \
     # Download yum repository data to cache
  && yum makecache \
     # Install default development tools (gcc, make, etc)
- && yum groupinstall -y "Development Tools" --setopt=group_package_types=mandatory,default
+ && yum groupinstall -y "Development Tools" --setopt=group_package_types=mandatory,default \
+ && yum install -y libffi libffi-devel
 
 
 # The default version of cmake is 2.8.12. We need cmake to build a few of
@@ -471,6 +472,7 @@ RUN CFLAGS="-fstack-protector-strong -fpic -fpie -O3 -I${INSTALL_DIR}/include -I
         --enable-intl=shared \
         --enable-soap \
         --with-xsl=${INSTALL_DIR} \
+        --with-ffi \
         # necessary for `pecl` to work (to install PHP extensions)
         --with-pear \
         # extra compilation flags

--- a/php-84/Dockerfile
+++ b/php-84/Dockerfile
@@ -18,8 +18,7 @@ RUN set -xe \
     # Download yum repository data to cache
  && yum makecache \
     # Install default development tools (gcc, make, etc)
- && yum groupinstall -y "Development Tools" --setopt=group_package_types=mandatory,default \
- && yum install -y libffi libffi-devel
+ && yum groupinstall -y "Development Tools" --setopt=group_package_types=mandatory,default
 
 
 # The default version of cmake is 2.8.12. We need cmake to build a few of
@@ -405,7 +404,8 @@ RUN make && make install
 # gettext-devel : needed for the --with-gettext flag
 # libicu-devel : needed for intl
 # libxslt-devel : needed for the XSL extension
-RUN LD_LIBRARY_PATH= yum install -y readline-devel gettext-devel libicu-devel libxslt-devel
+# libffi-devel : needed for the FFI extension
+RUN LD_LIBRARY_PATH= yum install -y readline-devel gettext-devel libicu-devel libxslt-devel libffi-devel
 
 
 # Note: this variable is used when building extra/custom extensions, do not remove

--- a/tests/test_2_extensions.php
+++ b/tests/test_2_extensions.php
@@ -64,6 +64,7 @@ $coreExtensions = [
     'readline' => READLINE_LIB === 'readline',
     'reflection' => class_exists(\ReflectionClass::class),
     'session' => session_status() === PHP_SESSION_NONE,
+    'ffi' => class_exists(\FFI::class),
     'zip' => class_exists(\ZipArchive::class),
     'zlib' => md5(gzcompress('abcde')) === 'db245560922b42f1935e73e20b30980e',
 ];
@@ -94,11 +95,11 @@ $extensions = [
         if ($private_key === false) {
             return false;
         }
-    
+
         $public_key_pem = openssl_pkey_get_details($private_key)['key'];
         $details = openssl_pkey_get_details(openssl_pkey_get_public($public_key_pem));
         return $details['bits'] === 2048;
-    })(),    
+    })(),
     'json' => function_exists('json_encode'),
     'bcmath' => function_exists('bcadd'),
     'ctype' => function_exists('ctype_digit'),


### PR DESCRIPTION
After chatting about this [here](https://github.com/brefphp/bref/issues/1888#issuecomment-2812097709), I've tried enabling the FFI extension to allow the use of the [libsql-php](https://github.com/tursodatabase/libsql-php) library.