### PR TITLE
Fix some internal fatal errors not logged by forcing `display_errors=1` in the bootstrap process

### DIFF
--- a/layers/bootstrap.php
+++ b/layers/bootstrap.php
@@ -1,5 +1,11 @@
 <?php declare(strict_types=1);
 
+// Force errors to be logged to stdout so that they end up in CloudWatch.
+// In the `function` runtime this is already `1`, but in the `fpm` runtime it is `0` by default.
+// Here we are forcing it to `1` in the bootstrap process, it will not impact the application code
+// as it runs in different processes (FPM worker) and those will have `display_errors=0`.
+ini_set('display_errors', '1');
+
 $appRoot = getenv('LAMBDA_TASK_ROOT');
 
 $autoloadPath = $_SERVER['BREF_AUTOLOAD_PATH'] ?? null;


### PR DESCRIPTION
In the `fpm` runtime, fatal errors in the bootstrap process don't have their details logged.

Reported in Slack: https://brefworkspace.slack.com/archives/C057S6G4Z9N/p1750813674579189?thread_ts=1750740077.495139&cid=C057S6G4Z9N

Here is to illustrate:

- FPM runtime (no error details)

![Screen-002934](https://github.com/user-attachments/assets/38bb8eea-842b-4614-b720-a6a200370cd6)

- Function runtime

![Screen-002936](https://github.com/user-attachments/assets/36f2e5da-4338-4e3d-919a-99eba6ea637f)

The reason is that `display_errors=0` in the FPM runtime because we don't want errors in the application to be logged to `stdout` (because `stdout` is the HTTP response). However this is an issue in the bootstrap process: errors are then not logged (some errors, not all of them).

This PR forces `display_errors=1` in the bootstrap process regardless of the runtime.