### PR TITLE
Add PHP 8.5 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
                     script: |
                         const matrix = {
                             cpu: ['x86', 'arm'],
-                            php_version: ['80', '81', '82', '83', '84'],
+                            php_version: ['80', '81', '82', '83', '84', '85'],
                         }
                         
                         // If this is a third-party pull request, skip ARM builds

--- a/Makefile
+++ b/Makefile
@@ -35,13 +35,13 @@ default: docker-images layers
 
 
 # Build Docker images *locally*
-docker-images: docker-images-php-80 docker-images-php-81 docker-images-php-82 docker-images-php-83 docker-images-php-84
+docker-images: docker-images-php-80 docker-images-php-81 docker-images-php-82 docker-images-php-83 docker-images-php-84 docker-images-php-85
 docker-images-php-%:
 	PHP_VERSION=$* ${BAKE_COMMAND} --load
 
 
 # Build Lambda layers (zip files) *locally*
-layers: layer-php-80 layer-php-81 layer-php-82 layer-php-83 layer-php-84 layer-php-80-fpm layer-php-81-fpm layer-php-82-fpm layer-php-83-fpm layer-php-84-fpm
+layers: layer-php-80 layer-php-81 layer-php-82 layer-php-83 layer-php-84 layer-php-85 layer-php-80-fpm layer-php-81-fpm layer-php-82-fpm layer-php-83-fpm layer-php-84-fpm layer-php-85-fpm
 	# Build the console layer only once (x86 and single PHP version)
 	@if [ ${CPU} = "x86" ]; then \
 		$(MAKE) layer-console; \
@@ -57,7 +57,7 @@ layer-%:
 # Upload the layers to AWS Lambda
 # Uses the current AWS_PROFILE. Most users will not want to use this option
 # as this will publish all layers to all regions + publish all Docker images.
-upload-layers: upload-layers-php-80 upload-layers-php-81 upload-layers-php-82 upload-layers-php-83 upload-layers-php-84
+upload-layers: upload-layers-php-80 upload-layers-php-81 upload-layers-php-82 upload-layers-php-83 upload-layers-php-84 upload-layers-php-85
 	# Upload the console layer only once (x86 and single PHP version)
 	@if [ ${CPU} = "x86" ]; then \
 		LAYER_NAME=console $(MAKE) -C ./utils/lambda-publish publish-parallel; \
@@ -70,7 +70,7 @@ upload-layers-php-%:
 
 
 # Publish Docker images to Docker Hub.
-upload-to-docker-hub: upload-to-docker-hub-php-80 upload-to-docker-hub-php-81 upload-to-docker-hub-php-82 upload-to-docker-hub-php-83 upload-to-docker-hub-php-84
+upload-to-docker-hub: upload-to-docker-hub-php-80 upload-to-docker-hub-php-81 upload-to-docker-hub-php-82 upload-to-docker-hub-php-83 upload-to-docker-hub-php-84 upload-to-docker-hub-php-85
 upload-to-docker-hub-php-%:
     # Make sure we have defined the docker tag
 	(test $(DOCKER_TAG)) && echo "Tagging images with \"${DOCKER_TAG}\"" || echo "You have to define environment variable DOCKER_TAG"
@@ -89,12 +89,12 @@ upload-to-docker-hub-php-%:
 	done
 
 
-test: test-80 test-81 test-82 test-83 test-84
+test: test-80 test-81 test-82 test-83 test-84 test-85
 test-%:
 	cd tests && $(MAKE) test-$*
 
 
-clean: clean-80 clean-81 clean-82 clean-83 clean-84
+clean: clean-80 clean-81 clean-82 clean-83 clean-84 clean-85
 	# Clear the build cache, else all images will be rebuilt using cached layers
 	docker builder prune
 	# Remove zip files

--- a/layers/fpm-dev/Dockerfile
+++ b/layers/fpm-dev/Dockerfile
@@ -16,8 +16,8 @@ RUN cp $(php -r "echo ini_get('extension_dir');")/xdebug.so /opt/bref/extensions
 # Install Blackfire
 # https://blackfire.io/docs/up-and-running/installation?action=install&mode=full&version=latest&mode=full&location=server&os=manual&language=php#install-the-php-probe
 ARG BLACKFIRE_VERSION=1.87.2
-RUN if [ $PHP_VERSION != "83" ] && [ $PHP_VERSION != "84" ] && [ $CPU_PREFIX == "" ]; then curl -A "Docker" -o /opt/bref/extensions/blackfire.so -L -s "https://packages.blackfire.io/binaries/blackfire-php/$BLACKFIRE_VERSION/blackfire-php-linux_amd64-php-"$PHP_VERSION".so"; fi
-RUN if [ $PHP_VERSION != "83" ] && [ $PHP_VERSION != "84" ] && [ $CPU_PREFIX == "arm-" ]; then curl -A "Docker" -o /opt/bref/extensions/blackfire.so -L -s "https://packages.blackfire.io/binaries/blackfire-php/$BLACKFIRE_VERSION/blackfire-php-linux_arm64-php-"$PHP_VERSION".so"; fi
+RUN if [ $PHP_VERSION != "83" ] && [ $PHP_VERSION != "84" ] && [ $PHP_VERSION != "85" ] && [ $CPU_PREFIX == "" ]; then curl -A "Docker" -o /opt/bref/extensions/blackfire.so -L -s "https://packages.blackfire.io/binaries/blackfire-php/$BLACKFIRE_VERSION/blackfire-php-linux_amd64-php-"$PHP_VERSION".so"; fi
+RUN if [ $PHP_VERSION != "83" ] && [ $PHP_VERSION != "84" ] && [ $PHP_VERSION != "85" ] && [ $CPU_PREFIX == "arm-" ]; then curl -A "Docker" -o /opt/bref/extensions/blackfire.so -L -s "https://packages.blackfire.io/binaries/blackfire-php/$BLACKFIRE_VERSION/blackfire-php-linux_arm64-php-"$PHP_VERSION".so"; fi
 
 
 FROM bref/${CPU_PREFIX}php-${PHP_VERSION}-fpm

--- a/layers/fpm-dev/Dockerfile
+++ b/layers/fpm-dev/Dockerfile
@@ -10,8 +10,8 @@ ARG PHP_VERSION
 RUN mkdir -p /opt/bref/extensions
 
 # Install xdebug
-RUN pecl install xdebug-3.4.5
-RUN cp $(php -r "echo ini_get('extension_dir');")/xdebug.so /opt/bref/extensions
+RUN if [ $PHP_VERSION != "85" ]; then pecl install xdebug-3.4.5; fi
+RUN if [ $PHP_VERSION != "85" ]; then cp $(php -r "echo ini_get('extension_dir');")/xdebug.so /opt/bref/extensions; fi
 
 # Install Blackfire
 # https://blackfire.io/docs/up-and-running/installation?action=install&mode=full&version=latest&mode=full&location=server&os=manual&language=php#install-the-php-probe

--- a/layers/fpm/bref.ini
+++ b/layers/fpm/bref.ini
@@ -47,4 +47,3 @@ upload_max_filesize=6M
 extension_dir=/opt/bref/extensions
 ; Extensions enabled by default
 extension=pdo_mysql.so
-zend_extension=opcache.so

--- a/layers/function/bref.ini
+++ b/layers/function/bref.ini
@@ -41,4 +41,3 @@ variables_order="EGPCS"
 extension_dir=/opt/bref/extensions
 ; Extensions enabled by default
 extension=pdo_mysql.so
-zend_extension=opcache.so

--- a/layers/opcache.ini
+++ b/layers/opcache.ini
@@ -1,0 +1,1 @@
+zend_extension=opcache.so

--- a/php-80/Dockerfile
+++ b/php-80/Dockerfile
@@ -514,6 +514,7 @@ COPY --link layers/bootstrap.php /opt/bref/bootstrap.php
 FROM isolation as function
 
 COPY --link layers/function/bref.ini /opt/bref/etc/php/conf.d/
+COPY --link layers/opcache.ini /opt/bref/etc/php/conf.d/
 
 COPY --link layers/function/bootstrap.sh /opt/bootstrap
 # Copy files to /var/runtime to support deploying as a Docker image
@@ -537,6 +538,7 @@ FROM isolation as fpm
 COPY --link --from=fpm-extension /bref-layer /opt
 
 COPY --link layers/fpm/bref.ini /opt/bref/etc/php/conf.d/
+COPY --link layers/opcache.ini /opt/bref/etc/php/conf.d/
 
 COPY --link layers/fpm/bootstrap.sh /opt/bootstrap
 # Copy files to /var/runtime to support deploying as a Docker image

--- a/php-81/Dockerfile
+++ b/php-81/Dockerfile
@@ -536,6 +536,7 @@ COPY --link layers/bootstrap.php /opt/bref/bootstrap.php
 FROM isolation as function
 
 COPY --link layers/function/bref.ini /opt/bref/etc/php/conf.d/
+COPY --link layers/opcache.ini /opt/bref/etc/php/conf.d/
 
 COPY --link layers/function/bootstrap.sh /opt/bootstrap
 # Copy files to /var/runtime to support deploying as a Docker image
@@ -559,6 +560,7 @@ FROM isolation as fpm
 COPY --link --from=fpm-extension /bref-layer /opt
 
 COPY --link layers/fpm/bref.ini /opt/bref/etc/php/conf.d/
+COPY --link layers/opcache.ini /opt/bref/etc/php/conf.d/
 
 COPY --link layers/fpm/bootstrap.sh /opt/bootstrap
 # Copy files to /var/runtime to support deploying as a Docker image

--- a/php-82/Dockerfile
+++ b/php-82/Dockerfile
@@ -536,6 +536,7 @@ COPY --link layers/bootstrap.php /opt/bref/bootstrap.php
 FROM isolation as function
 
 COPY --link layers/function/bref.ini /opt/bref/etc/php/conf.d/
+COPY --link layers/opcache.ini /opt/bref/etc/php/conf.d/
 
 COPY --link layers/function/bootstrap.sh /opt/bootstrap
 # Copy files to /var/runtime to support deploying as a Docker image
@@ -559,6 +560,7 @@ FROM isolation as fpm
 COPY --link --from=fpm-extension /bref-layer /opt
 
 COPY --link layers/fpm/bref.ini /opt/bref/etc/php/conf.d/
+COPY --link layers/opcache.ini /opt/bref/etc/php/conf.d/
 
 COPY --link layers/fpm/bootstrap.sh /opt/bootstrap
 # Copy files to /var/runtime to support deploying as a Docker image

--- a/php-83/Dockerfile
+++ b/php-83/Dockerfile
@@ -536,6 +536,7 @@ COPY --link layers/bootstrap.php /opt/bref/bootstrap.php
 FROM isolation as function
 
 COPY --link layers/function/bref.ini /opt/bref/etc/php/conf.d/
+COPY --link layers/opcache.ini /opt/bref/etc/php/conf.d/
 
 COPY --link layers/function/bootstrap.sh /opt/bootstrap
 # Copy files to /var/runtime to support deploying as a Docker image
@@ -559,6 +560,7 @@ FROM isolation as fpm
 COPY --link --from=fpm-extension /bref-layer /opt
 
 COPY --link layers/fpm/bref.ini /opt/bref/etc/php/conf.d/
+COPY --link layers/opcache.ini /opt/bref/etc/php/conf.d/
 
 COPY --link layers/fpm/bootstrap.sh /opt/bootstrap
 # Copy files to /var/runtime to support deploying as a Docker image

--- a/php-84/Dockerfile
+++ b/php-84/Dockerfile
@@ -537,6 +537,7 @@ COPY --link layers/bootstrap.php /opt/bref/bootstrap.php
 FROM isolation as function
 
 COPY --link layers/function/bref.ini /opt/bref/etc/php/conf.d/
+COPY --link layers/opcache.ini /opt/bref/etc/php/conf.d/
 
 COPY --link layers/function/bootstrap.sh /opt/bootstrap
 # Copy files to /var/runtime to support deploying as a Docker image
@@ -560,6 +561,7 @@ FROM isolation as fpm
 COPY --link --from=fpm-extension /bref-layer /opt
 
 COPY --link layers/fpm/bref.ini /opt/bref/etc/php/conf.d/
+COPY --link layers/opcache.ini /opt/bref/etc/php/conf.d/
 
 COPY --link layers/fpm/bootstrap.sh /opt/bootstrap
 # Copy files to /var/runtime to support deploying as a Docker image

--- a/php-85/Dockerfile
+++ b/php-85/Dockerfile
@@ -4,7 +4,7 @@
 ARG IMAGE_VERSION_SUFFIX
 
 # https://www.php.net/downloads
-ARG VERSION_PHP=8.4.11
+ARG VERSION_PHP=8.5.0alpha4
 
 
 # Lambda uses a custom AMI named Amazon Linux 2
@@ -427,7 +427,7 @@ WORKDIR ${PHP_BUILD_DIR}
 # --silent will hide the progress, but also the errors: we restore error messages with --show-error
 # --fail makes sure that curl returns an error instead of fetching the 404 page
 ARG VERSION_PHP
-RUN curl --location --silent --show-error --fail https://www.php.net/get/php-${VERSION_PHP}.tar.gz/from/this/mirror \
+RUN curl --location --silent --show-error --fail https://downloads.php.net/~daniels/php-${VERSION_PHP}.tar.gz \
   | tar xzC . --strip-components=1
 
 # Configure the build

--- a/php-85/Dockerfile
+++ b/php-85/Dockerfile
@@ -4,7 +4,7 @@
 ARG IMAGE_VERSION_SUFFIX
 
 # https://www.php.net/downloads
-ARG VERSION_PHP=8.5.0alpha4
+ARG VERSION_PHP=8.5.0beta1
 
 
 # Lambda uses a custom AMI named Amazon Linux 2
@@ -134,9 +134,41 @@ RUN mkdir -p ${INSTALL_DIR}/bref/ssl && curl -Lk -o ${CA_BUNDLE} ${CA_BUNDLE_SOU
 
 
 ###############################################################################
+# ICU
+# We need to compile ICU from source because Amazon Linux 2 only has ICU 50.2
+# but PHP 8.5 requires ICU 57.1 or higher
+# https://github.com/unicode-org/icu/releases
+# Uses:
+#   - None
+# Needed by:
+#   - libxml2
+#   - php intl extension
+ENV VERSION_ICU=77.1
+ENV ICU_BUILD_DIR=${BUILD_DIR}/icu
+RUN set -xe; \
+    mkdir -p ${ICU_BUILD_DIR}; \
+    curl -Ls https://github.com/unicode-org/icu/releases/download/release-${VERSION_ICU//./-}/icu4c-${VERSION_ICU//./_}-src.tgz \
+    | tar xzC ${ICU_BUILD_DIR} --strip-components=1
+WORKDIR ${ICU_BUILD_DIR}/source
+RUN CFLAGS="" \
+    CPPFLAGS="-I${INSTALL_DIR}/include -I/usr/include" \
+    LDFLAGS="-L${INSTALL_DIR}/lib64 -L${INSTALL_DIR}/lib -Wl,-rpath,${INSTALL_DIR}/lib" \
+    ./configure \
+    --prefix=${INSTALL_DIR} \
+    --enable-shared \
+    --disable-static \
+    --disable-samples \
+    --disable-tests \
+    --disable-extras \
+    --disable-layoutex
+RUN make && make install
+
+
+###############################################################################
 # LIBXML2
 # https://gitlab.gnome.org/GNOME/libxml2/-/releases
 # Uses:
+#   - icu
 #   - zlib
 # Needed by:
 #   - php
@@ -151,6 +183,9 @@ WORKDIR  ${XML2_BUILD_DIR}/
 RUN CFLAGS="" \
     CPPFLAGS="-I${INSTALL_DIR}/include -I/usr/include" \
     LDFLAGS="-L${INSTALL_DIR}/lib64 -L${INSTALL_DIR}/lib" \
+    PATH="${INSTALL_DIR}/bin:${PATH}" \
+    ICU_CFLAGS="-I${INSTALL_DIR}/include" \
+    ICU_LIBS="-L${INSTALL_DIR}/lib -licui18n -licuuc -licudata" \
     ./configure \
     --prefix=${INSTALL_DIR} \
     --with-sysroot=${INSTALL_DIR} \
@@ -402,10 +437,9 @@ RUN make && make install
 # Install some dev files for using old libraries already on the system
 # readline-devel : needed for the readline extension
 # gettext-devel : needed for the --with-gettext flag
-# libicu-devel : needed for intl
 # libxslt-devel : needed for the XSL extension
 # libffi-devel : needed for the FFI extension
-RUN LD_LIBRARY_PATH= yum install -y readline-devel gettext-devel libicu-devel libxslt-devel libffi-devel
+RUN LD_LIBRARY_PATH= yum install -y readline-devel gettext-devel libxslt-devel libffi-devel
 
 
 # Note: this variable is used when building extra/custom extensions, do not remove
@@ -427,7 +461,7 @@ WORKDIR ${PHP_BUILD_DIR}
 # --silent will hide the progress, but also the errors: we restore error messages with --show-error
 # --fail makes sure that curl returns an error instead of fetching the 404 page
 ARG VERSION_PHP
-RUN curl --location --silent --show-error --fail https://downloads.php.net/~daniels/php-${VERSION_PHP}.tar.gz \
+RUN curl --location --silent --show-error --fail https://downloads.php.net/~edorian/php-${VERSION_PHP}.tar.gz \
   | tar xzC . --strip-components=1
 
 # Configure the build
@@ -444,6 +478,7 @@ RUN ./buildconf --force
 RUN CFLAGS="-fstack-protector-strong -fpic -fpie -O3 -I${INSTALL_DIR}/include -I/usr/include -ffunction-sections -fdata-sections" \
         CPPFLAGS="-fstack-protector-strong -fpic -fpie -O3 -I${INSTALL_DIR}/include -I/usr/include -ffunction-sections -fdata-sections" \
         LDFLAGS="-L${INSTALL_DIR}/lib64 -L${INSTALL_DIR}/lib -Wl,-O1 -Wl,--strip-all -Wl,--hash-style=both -pie" \
+        PKG_CONFIG_PATH="${INSTALL_DIR}/lib/pkgconfig:${INSTALL_DIR}/lib64/pkgconfig" \
     ./configure \
         --prefix=${INSTALL_DIR} \
         --enable-option-checking=fatal \
@@ -513,7 +548,6 @@ COPY --link utils/lib-copy /bref/lib-copy
 RUN php /bref/lib-copy/copy-dependencies.php /bref-layer/bin/php /bref-layer/lib
 RUN php /bref/lib-copy/copy-dependencies.php /bref-layer/bref/extensions/apcu.so /bref-layer/lib
 RUN php /bref/lib-copy/copy-dependencies.php /bref-layer/bref/extensions/intl.so /bref-layer/lib
-RUN php /bref/lib-copy/copy-dependencies.php /bref-layer/bref/extensions/opcache.so /bref-layer/lib
 RUN php /bref/lib-copy/copy-dependencies.php /bref-layer/bref/extensions/pdo_mysql.so /bref-layer/lib
 RUN php /bref/lib-copy/copy-dependencies.php /bref-layer/bref/extensions/pdo_pgsql.so /bref-layer/lib
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,6 +1,6 @@
 export CPU_PREFIX ?=
 
-test: test-80 test-81 test-82 test-83 test-84
+test: test-80 test-81 test-82 test-83 test-84 test-85
 
 # This rule matches with a wildcard, for example `test-80`.
 # The `$*` variable will contained the matched part, in this case `80`.


### PR DESCRIPTION
Notable changes since PHP 8.4 impacting us:
* The opcache extension is no longer an extension as such and is part of core.
* A newer version of ICU is required, so we're building the latest from source.
* Xdebug doesn't support PHP 8.5 yet, so we're skipping installing it for now.
