### PR TITLE
Optimize layers by externalizing only large extensions

### DIFF
--- a/php-82/Dockerfile
+++ b/php-82/Dockerfile
@@ -150,19 +150,18 @@ RUN CFLAGS="-fstack-protector-strong -fpic -fpie -Os -I${INSTALL_DIR}/include -I
         --enable-exif \
         --enable-ftp \
         --with-gettext \
-        --enable-mbstring \
+        --enable-mbstring=shared \
         --with-pdo-mysql=mysqlnd \
         --with-mysqli \
         --enable-pcntl \
         --with-zip \
         --enable-bcmath \
-        --with-pdo-pgsql=shared \
+        --with-pdo-pgsql \
         # Separate .so extension so that it is not loaded by default
         --enable-intl=shared \
         # Separate .so extension so that it is not loaded by default
         --enable-soap=shared \
-        # Separate .so extension so that it is not loaded by default
-        --with-xsl=${INSTALL_DIR} \
+        --with-xsl \
         --with-ffi \
         # necessary for `pecl` to work (to install PHP extensions)
         --with-pear \

--- a/php-83/Dockerfile
+++ b/php-83/Dockerfile
@@ -150,19 +150,18 @@ RUN CFLAGS="-fstack-protector-strong -fpic -fpie -Os -I${INSTALL_DIR}/include -I
         --enable-exif \
         --enable-ftp \
         --with-gettext \
-        --enable-mbstring \
+        --enable-mbstring=shared \
         --with-pdo-mysql=mysqlnd \
         --with-mysqli \
         --enable-pcntl \
         --with-zip \
         --enable-bcmath \
-        --with-pdo-pgsql=shared \
+        --with-pdo-pgsql \
         # Separate .so extension so that it is not loaded by default
         --enable-intl=shared \
         # Separate .so extension so that it is not loaded by default
         --enable-soap=shared \
-        # Separate .so extension so that it is not loaded by default
-        --with-xsl=${INSTALL_DIR} \
+        --with-xsl \
         --with-ffi \
         # necessary for `pecl` to work (to install PHP extensions)
         --with-pear \

--- a/php-84/Dockerfile
+++ b/php-84/Dockerfile
@@ -149,19 +149,18 @@ RUN CFLAGS="-fstack-protector-strong -fpic -fpie -Os -I${INSTALL_DIR}/include -I
         --enable-exif \
         --enable-ftp \
         --with-gettext \
-        --enable-mbstring \
+        --enable-mbstring=shared \
         --with-pdo-mysql=mysqlnd \
         --with-mysqli \
         --enable-pcntl \
         --with-zip \
         --enable-bcmath \
-        --with-pdo-pgsql=shared \
+        --with-pdo-pgsql \
         # Separate .so extension so that it is not loaded by default
         --enable-intl=shared \
         # Separate .so extension so that it is not loaded by default
         --enable-soap=shared \
-        # Separate .so extension so that it is not loaded by default
-        --with-xsl=${INSTALL_DIR} \
+        --with-xsl \
         --with-ffi \
         # necessary for `pecl` to work (to install PHP extensions)
         --with-pear \

--- a/php-85/Dockerfile
+++ b/php-85/Dockerfile
@@ -149,19 +149,18 @@ RUN CFLAGS="-fstack-protector-strong -fpic -fpie -Os -I${INSTALL_DIR}/include -I
         --enable-exif \
         --enable-ftp \
         --with-gettext \
-        --enable-mbstring \
+        --enable-mbstring=shared \
         --with-pdo-mysql=mysqlnd \
         --with-mysqli \
         --enable-pcntl \
         --with-zip \
         --enable-bcmath \
-        --with-pdo-pgsql=shared \
+        --with-pdo-pgsql \
         # Separate .so extension so that it is not loaded by default
         --enable-intl=shared \
         # Separate .so extension so that it is not loaded by default
         --enable-soap=shared \
-        # Separate .so extension so that it is not loaded by default
-        --with-xsl=${INSTALL_DIR} \
+        --with-xsl \
         --with-ffi \
         # necessary for `pecl` to work (to install PHP extensions)
         --with-pear \

--- a/src/php-85.ini
+++ b/src/php-85.ini
@@ -51,3 +51,5 @@ post_max_size=6M
 upload_max_filesize=6M
 
 extension_dir=/opt/bref/extensions
+; Extensions enabled by default
+extension=mbstring

--- a/src/php.ini
+++ b/src/php.ini
@@ -52,4 +52,5 @@ upload_max_filesize=6M
 
 extension_dir=/opt/bref/extensions
 ; Extensions enabled by default
+extension=mbstring
 zend_extension=opcache.so

--- a/tests/test_3_manual_extensions.ini
+++ b/tests/test_3_manual_extensions.ini
@@ -1,4 +1,3 @@
 extension=intl
 extension=apcu
-extension=pdo_pgsql
 extension=soap


### PR DESCRIPTION
pdo-pgsql is 196KB (the smallest possible) so let's just build it in the PHP binaries (it will now be enabled by default).

I tested all other extensions, only `mbstring` is large: 1.2MB. By externalizing it into a `mbstring.so`, we avoid the duplication of this extension in the 2 PHP binaries.

That means the layers are 1.2MB smaller.