### PR TITLE
Add the Redis extension

### DIFF
--- a/php-82/Dockerfile
+++ b/php-82/Dockerfile
@@ -179,6 +179,7 @@ RUN set -xe; \
 # Install extensions
 # We can install extensions manually or using `pecl`
 RUN pecl install APCu
+RUN pecl install redis-6.2.0
 
 
 # ---------------------------------------------------------------

--- a/php-83/Dockerfile
+++ b/php-83/Dockerfile
@@ -179,6 +179,7 @@ RUN set -xe; \
 # Install extensions
 # We can install extensions manually or using `pecl`
 RUN pecl install APCu
+RUN pecl install redis-6.2.0
 
 
 # ---------------------------------------------------------------

--- a/php-84/Dockerfile
+++ b/php-84/Dockerfile
@@ -178,6 +178,7 @@ RUN set -xe; \
 # Install extensions
 # We can install extensions manually or using `pecl`
 RUN pecl install APCu
+RUN pecl install redis-6.2.0
 
 
 # ---------------------------------------------------------------

--- a/php-85/Dockerfile
+++ b/php-85/Dockerfile
@@ -178,6 +178,7 @@ RUN set -xe; \
 # Install extensions
 # We can install extensions manually or using `pecl`
 RUN pecl install APCu
+RUN pecl install redis-6.2.0
 
 
 # ---------------------------------------------------------------

--- a/tests/test_2_extensions.php
+++ b/tests/test_2_extensions.php
@@ -146,6 +146,7 @@ $extensionsDisabledByDefault = [
     'intl' => class_exists(\Collator::class),
     'apcu' => function_exists('apcu_add'),
     'soap' => class_exists(\SoapClient::class),
+    'redis' => class_exists(\Redis::class),
 ];
 foreach ($extensionsDisabledByDefault as $extension => $test) {
     if ($test) {

--- a/tests/test_3_manual_enabling_extensions.php
+++ b/tests/test_3_manual_enabling_extensions.php
@@ -6,6 +6,7 @@ $extensions = [
     'intl' => class_exists(\Collator::class),
     'apcu' => function_exists('apcu_add'),
     'soap' => class_exists(\SoapClient::class),
+    'redis' => class_exists(\Redis::class),
 ];
 
 $extensionDir = ini_get('extension_dir');

--- a/tests/test_3_manual_extensions.ini
+++ b/tests/test_3_manual_extensions.ini
@@ -1,3 +1,4 @@
 extension=intl
 extension=apcu
 extension=soap
+extension=redis


### PR DESCRIPTION
This extension is only 900KB, is very popular amongst Bref users, and considering Bref v3 has cold starts improved compared to v2, we have a little bit of room to add this one.