### PR TITLE
Rollback to `curl` 8.15.0 instead of 8.16.0

### DIFF
--- a/php-80/Dockerfile
+++ b/php-80/Dockerfile
@@ -253,7 +253,7 @@ RUN make -j $(nproc) && make install
 # #   - libnghttp2
 # # Needed by:
 # #   - php
-ENV VERSION_CURL=8.16.0
+ENV VERSION_CURL=8.15.0
 ENV CURL_BUILD_DIR=${BUILD_DIR}/curl
 RUN set -xe; \
     mkdir -p ${CURL_BUILD_DIR}/bin; \

--- a/php-81/Dockerfile
+++ b/php-81/Dockerfile
@@ -254,7 +254,7 @@ RUN make -j $(nproc) && make install
 # #   - libnghttp2
 # # Needed by:
 # #   - php
-ENV VERSION_CURL=8.16.0
+ENV VERSION_CURL=8.15.0
 ENV CURL_BUILD_DIR=${BUILD_DIR}/curl
 RUN set -xe; \
     mkdir -p ${CURL_BUILD_DIR}/bin; \

--- a/php-82/Dockerfile
+++ b/php-82/Dockerfile
@@ -254,7 +254,7 @@ RUN make -j $(nproc) && make install
 # #   - libnghttp2
 # # Needed by:
 # #   - php
-ENV VERSION_CURL=8.16.0
+ENV VERSION_CURL=8.15.0
 ENV CURL_BUILD_DIR=${BUILD_DIR}/curl
 RUN set -xe; \
     mkdir -p ${CURL_BUILD_DIR}/bin; \

--- a/php-83/Dockerfile
+++ b/php-83/Dockerfile
@@ -254,7 +254,7 @@ RUN make -j $(nproc) && make install
 # #   - libnghttp2
 # # Needed by:
 # #   - php
-ENV VERSION_CURL=8.16.0
+ENV VERSION_CURL=8.15.0
 ENV CURL_BUILD_DIR=${BUILD_DIR}/curl
 RUN set -xe; \
     mkdir -p ${CURL_BUILD_DIR}/bin; \

--- a/php-84/Dockerfile
+++ b/php-84/Dockerfile
@@ -254,7 +254,7 @@ RUN make -j $(nproc) && make install
 # #   - libnghttp2
 # # Needed by:
 # #   - php
-ENV VERSION_CURL=8.16.0
+ENV VERSION_CURL=8.15.0
 ENV CURL_BUILD_DIR=${BUILD_DIR}/curl
 RUN set -xe; \
     mkdir -p ${CURL_BUILD_DIR}/bin; \


### PR DESCRIPTION
We're seeing loads of crashes on 8.16.0.