### PR TITLE
Always log errors to stderr

### DIFF
--- a/src/php-85.ini
+++ b/src/php-85.ini
@@ -1,6 +1,6 @@
-; On the CLI we want errors to be sent to stdout -> those will end up in CloudWatch
-; In FPM workers we don't want that, but that is overridden by Bref when it starts PHP-FPM
-display_errors=1
+; We want errors to be sent to stderr -> those will end up in CloudWatch
+display_errors=0
+log_errors=1
 
 ; Since PHP 7.4 the default value is E_ALL
 ; We override it to set the recommended configuration value for production.

--- a/src/php.ini
+++ b/src/php.ini
@@ -1,6 +1,6 @@
-; On the CLI we want errors to be sent to stdout -> those will end up in CloudWatch
-; In FPM workers we don't want that, but that is overridden by Bref when it starts PHP-FPM
-display_errors=1
+; We want errors to be sent to stderr -> those will end up in CloudWatch
+display_errors=0
+log_errors=1
 
 ; Since PHP 7.4 the default value is E_ALL
 ; We override it to set the recommended configuration value for production.


### PR DESCRIPTION
2 birds in one stone:

- will avoid the blank screen with FPM with no logs when an error happens too soon in the process (https://github.com/brefphp/bref/issues/2037#issuecomment-3655565505)
- unifies CLI and FPM: always log to stderr, avoids having to override that flag in the `FpmRuntime` (https://github.com/brefphp/bref/blob/5e0447bfb5f2a5f575935f8f30edaccb0305969c/src/FpmRuntime/FpmHandler.php#L89)