### PR TITLE
Update PHP 8.4.19 and PHP 8.5.4

### DIFF
--- a/php-84/Dockerfile
+++ b/php-84/Dockerfile
@@ -4,7 +4,7 @@
 ARG IMAGE_VERSION_SUFFIX
 
 # https://www.php.net/downloads
-ARG VERSION_PHP=8.4.18
+ARG VERSION_PHP=8.4.19
 
 
 # Lambda uses a custom AMI named Amazon Linux 2023

--- a/php-85/Dockerfile
+++ b/php-85/Dockerfile
@@ -4,7 +4,7 @@
 ARG IMAGE_VERSION_SUFFIX
 
 # https://www.php.net/downloads
-ARG VERSION_PHP=8.5.3
+ARG VERSION_PHP=8.5.4
 
 
 # Lambda uses a custom AMI named Amazon Linux 2023


### PR DESCRIPTION
## Summary
- Update PHP 8.4: 8.4.18 → 8.4.19
- Update PHP 8.5: 8.5.3 → 8.5.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)