### PR TITLE
[3.x] Skip publishing to `me-south-1` region

### DIFF
--- a/utils/lambda-publish/Makefile
+++ b/utils/lambda-publish/Makefile
@@ -51,5 +51,5 @@ asia-southeast-1:
 
 miscellaneous:
 	REGION=af-south-1 ./publish.sh #Africa (Cape Town)
-	REGION=me-south-1 ./publish.sh #Middle East (Bahrain)
+	#REGION=me-south-1 ./publish.sh #Middle East (Bahrain)
 	#REGION=me-central-1 ./publish.sh #Middle East (UAE)


### PR DESCRIPTION
This region is in a sorry state of affairs, similar to `me-central-1`,