### PR TITLE
Update PHP versions to 8.4.22 and 8.5.7

### DIFF
--- a/php-84/Dockerfile
+++ b/php-84/Dockerfile
@@ -4,7 +4,7 @@
 ARG IMAGE_VERSION_SUFFIX
 
 # https://www.php.net/downloads
-ARG VERSION_PHP=8.4.21
+ARG VERSION_PHP=8.4.22
 
 
 # Lambda uses a custom AMI named Amazon Linux 2023

--- a/php-85/Dockerfile
+++ b/php-85/Dockerfile
@@ -4,7 +4,7 @@
 ARG IMAGE_VERSION_SUFFIX
 
 # https://www.php.net/downloads
-ARG VERSION_PHP=8.5.6
+ARG VERSION_PHP=8.5.7
 
 
 # Lambda uses a custom AMI named Amazon Linux 2023


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Updates the PHP patch versions used in the Lambda layer Docker builds:

- PHP 8.4: 8.4.21 → 8.4.22
- PHP 8.5: 8.5.6 → 8.5.7
<!-- CURSOR_AGENT_PR_BODY_END -->

