### PR TITLE
[2.x] Upgrade PHP to the latest patch releases

### DIFF
--- a/php-82/Dockerfile
+++ b/php-82/Dockerfile
@@ -4,7 +4,7 @@
 ARG IMAGE_VERSION_SUFFIX
 
 # https://www.php.net/downloads
-ARG VERSION_PHP=8.2.31
+ARG VERSION_PHP=8.2.32
 
 
 # Lambda uses a custom AMI named Amazon Linux 2

--- a/php-83/Dockerfile
+++ b/php-83/Dockerfile
@@ -4,7 +4,7 @@
 ARG IMAGE_VERSION_SUFFIX
 
 # https://www.php.net/downloads
-ARG VERSION_PHP=8.3.31
+ARG VERSION_PHP=8.3.32
 
 
 # Lambda uses a custom AMI named Amazon Linux 2

--- a/php-84/Dockerfile
+++ b/php-84/Dockerfile
@@ -4,7 +4,7 @@
 ARG IMAGE_VERSION_SUFFIX
 
 # https://www.php.net/downloads
-ARG VERSION_PHP=8.4.21
+ARG VERSION_PHP=8.4.23
 
 
 # Lambda uses a custom AMI named Amazon Linux 2


### PR DESCRIPTION
This updates the PHP pins to the current patch releases: 8.2.32, 8.3.32 and 8.4.23, with 8.0.30 and 8.1.34 already at their final versions. PHP 8.4.23 includes the upstream fix restoring the Spoofchecker ICU version guard, so building 8.4 against Amazon Linux 2's ICU 50 no longer needs the workaround this pull request previously carried.