### PR TITLE
[2.x] Build curl from the official release tarball

### DIFF
--- a/php-80/Dockerfile
+++ b/php-80/Dockerfile
@@ -257,11 +257,10 @@ ENV VERSION_CURL=8.15.0
 ENV CURL_BUILD_DIR=${BUILD_DIR}/curl
 RUN set -xe; \
     mkdir -p ${CURL_BUILD_DIR}/bin; \
-    curl -Ls https://github.com/curl/curl/archive/curl-${VERSION_CURL//./_}.tar.gz \
+    curl -Ls https://github.com/curl/curl/releases/download/curl-${VERSION_CURL//./_}/curl-${VERSION_CURL}.tar.gz \
     | tar xzC ${CURL_BUILD_DIR} --strip-components=1
 WORKDIR  ${CURL_BUILD_DIR}/
-RUN ./buildconf \
- && CFLAGS="" \
+RUN CFLAGS="" \
     CPPFLAGS="-I${INSTALL_DIR}/include -I/usr/include" \
     LDFLAGS="-L${INSTALL_DIR}/lib64 -L${INSTALL_DIR}/lib" \
     ./configure \

--- a/php-81/Dockerfile
+++ b/php-81/Dockerfile
@@ -258,11 +258,10 @@ ENV VERSION_CURL=8.15.0
 ENV CURL_BUILD_DIR=${BUILD_DIR}/curl
 RUN set -xe; \
     mkdir -p ${CURL_BUILD_DIR}/bin; \
-    curl -Ls https://github.com/curl/curl/archive/curl-${VERSION_CURL//./_}.tar.gz \
+    curl -Ls https://github.com/curl/curl/releases/download/curl-${VERSION_CURL//./_}/curl-${VERSION_CURL}.tar.gz \
     | tar xzC ${CURL_BUILD_DIR} --strip-components=1
 WORKDIR  ${CURL_BUILD_DIR}/
-RUN ./buildconf \
- && CFLAGS="" \
+RUN CFLAGS="" \
     CPPFLAGS="-I${INSTALL_DIR}/include -I/usr/include" \
     LDFLAGS="-L${INSTALL_DIR}/lib64 -L${INSTALL_DIR}/lib" \
     ./configure \

--- a/php-82/Dockerfile
+++ b/php-82/Dockerfile
@@ -258,11 +258,10 @@ ENV VERSION_CURL=8.15.0
 ENV CURL_BUILD_DIR=${BUILD_DIR}/curl
 RUN set -xe; \
     mkdir -p ${CURL_BUILD_DIR}/bin; \
-    curl -Ls https://github.com/curl/curl/archive/curl-${VERSION_CURL//./_}.tar.gz \
+    curl -Ls https://github.com/curl/curl/releases/download/curl-${VERSION_CURL//./_}/curl-${VERSION_CURL}.tar.gz \
     | tar xzC ${CURL_BUILD_DIR} --strip-components=1
 WORKDIR  ${CURL_BUILD_DIR}/
-RUN ./buildconf \
- && CFLAGS="" \
+RUN CFLAGS="" \
     CPPFLAGS="-I${INSTALL_DIR}/include -I/usr/include" \
     LDFLAGS="-L${INSTALL_DIR}/lib64 -L${INSTALL_DIR}/lib" \
     ./configure \

--- a/php-83/Dockerfile
+++ b/php-83/Dockerfile
@@ -258,11 +258,10 @@ ENV VERSION_CURL=8.15.0
 ENV CURL_BUILD_DIR=${BUILD_DIR}/curl
 RUN set -xe; \
     mkdir -p ${CURL_BUILD_DIR}/bin; \
-    curl -Ls https://github.com/curl/curl/archive/curl-${VERSION_CURL//./_}.tar.gz \
+    curl -Ls https://github.com/curl/curl/releases/download/curl-${VERSION_CURL//./_}/curl-${VERSION_CURL}.tar.gz \
     | tar xzC ${CURL_BUILD_DIR} --strip-components=1
 WORKDIR  ${CURL_BUILD_DIR}/
-RUN ./buildconf \
- && CFLAGS="" \
+RUN CFLAGS="" \
     CPPFLAGS="-I${INSTALL_DIR}/include -I/usr/include" \
     LDFLAGS="-L${INSTALL_DIR}/lib64 -L${INSTALL_DIR}/lib" \
     ./configure \

--- a/php-84/Dockerfile
+++ b/php-84/Dockerfile
@@ -258,11 +258,10 @@ ENV VERSION_CURL=8.15.0
 ENV CURL_BUILD_DIR=${BUILD_DIR}/curl
 RUN set -xe; \
     mkdir -p ${CURL_BUILD_DIR}/bin; \
-    curl -Ls https://github.com/curl/curl/archive/curl-${VERSION_CURL//./_}.tar.gz \
+    curl -Ls https://github.com/curl/curl/releases/download/curl-${VERSION_CURL//./_}/curl-${VERSION_CURL}.tar.gz \
     | tar xzC ${CURL_BUILD_DIR} --strip-components=1
 WORKDIR  ${CURL_BUILD_DIR}/
-RUN ./buildconf \
- && CFLAGS="" \
+RUN CFLAGS="" \
     CPPFLAGS="-I${INSTALL_DIR}/include -I/usr/include" \
     LDFLAGS="-L${INSTALL_DIR}/lib64 -L${INSTALL_DIR}/lib" \
     ./configure \


### PR DESCRIPTION
The curl build currently downloads GitHub's auto-generated git archive tarball, which is a raw snapshot of the tagged tree: its curlver.h still carries the -DEV suffix, so every layer ships a libcurl that reports itself as, for example, 8.15.0-DEV instead of 8.15.0, and the tree needs buildconf to generate configure before building. This switches the download to the official release tarball that the curl maintainers publish as a GitHub release asset, which has the version properly stamped and ships a pre-generated configure script, so the buildconf step is dropped and the built libcurl reports the true release version. This matters because Guzzle compares the curl version using `version_compare`.